### PR TITLE
fix: extract the real public key from WebAuthn credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,11 @@ jobs:
         env:
           CI: true
 
+      - name: Run WebAuthn attestation parsing tests
+        run: pnpm exec playwright test tests/webauthn-attestation-parsing.test.js --project=chromium --reporter=github
+        env:
+          CI: true
+
       - name: Upload test artifacts
         if: failure()
         uses: actions/upload-artifact@v7

--- a/src/webauthn/provider.js
+++ b/src/webauthn/provider.js
@@ -293,51 +293,36 @@ export class WebAuthnDIDProvider {
   }
 
   /**
-   * Extract P-256 public key from WebAuthn credential
-   * Parses the CBOR attestation object to get the real public key
-   */
-  /**
-   * Extract and normalize WebAuthn public key data from a credential response.
+   * Extract and normalize the WebAuthn public key from a credential response.
+   *
+   * Tries getPublicKey() first, then parses the attestation object. Falls back
+   * to a synthetic key derived from the credential ID only if both fail; that
+   * fallback is marked with `synthetic: true` and cannot verify authenticator
+   * signatures.
+   *
    * @param {PublicKeyCredential} credential - WebAuthn credential response.
    * @returns {Promise<Object>} Parsed credential info with public key.
    */
   static async extractPublicKey(credential) {
+    // Preferred path: the browser hands us the SPKI directly (WebAuthn L2).
+    // Available on AuthenticatorAttestationResponse only, i.e. after
+    // navigator.credentials.create() — never after .get().
     try {
-      // Import CBOR decoder for parsing attestation object
-      const cbor = await import('cbor-web');
-      const decode = cbor.decode || cbor.default?.decode || cbor.default;
-
-      if (typeof decode !== 'function') {
-        throw new Error('CBOR decoder not available from cbor-web');
+      const spki = credential?.response?.getPublicKey?.();
+      if (spki) {
+        return await WebAuthnDIDProvider.parseSpkiPublicKey(spki);
       }
-
-      const attestationObject = decode(
-        new Uint8Array(credential.response.attestationObject)
+    } catch (error) {
+      webauthnLog(
+        'getPublicKey() unavailable or unparsable, falling back to attestation parsing: %s',
+        error.message
       );
-      const authData = attestationObject.authData;
+    }
 
-      // Parse authenticator data structure
-      // Skip: rpIdHash (32 bytes) + flags (1 byte) + signCount (4 bytes)
-      const credentialDataStart = 32 + 1 + 4 + 16 + 2; // +16 for AAGUID, +2 for credentialIdLength
-      const credentialIdLength = new DataView(
-        authData.buffer,
-        32 + 1 + 4 + 16,
-        2
-      ).getUint16(0);
-      const publicKeyDataStart = credentialDataStart + credentialIdLength;
-
-      // Extract and decode the public key (CBOR format)
-      const publicKeyData = authData.slice(publicKeyDataStart);
-      const publicKeyObject = decode(publicKeyData);
-
-      // Extract P-256 coordinates (COSE key format)
-      return {
-        algorithm: publicKeyObject[3], // alg parameter
-        x: new Uint8Array(publicKeyObject[-2]), // x coordinate
-        y: new Uint8Array(publicKeyObject[-3]), // y coordinate
-        keyType: publicKeyObject[1], // kty parameter
-        curve: publicKeyObject[-1], // crv parameter
-      };
+    try {
+      return await WebAuthnDIDProvider.parseAttestedCredentialPublicKey(
+        credential.response.attestationObject
+      );
     } catch (error) {
       console.warn(
         'Failed to extract real public key from WebAuthn credential, using fallback:',
@@ -370,10 +355,154 @@ export class WebAuthnDIDProvider {
         y: ySeed.slice(0, 32), // Deterministic y coordinate based on credential
         keyType: 2, // EC2 key type
         curve: 1, // P-256 curve
+        // Marks a key that is NOT the authenticator's key. Signatures made by
+        // the authenticator cannot be verified against it.
+        synthetic: true,
       };
 
       return fallbackKey;
     }
+  }
+
+  /**
+   * Parse a SPKI-encoded (DER) P-256 public key into COSE-style coordinates.
+   * @param {ArrayBuffer|Uint8Array} spki - SPKI bytes from getPublicKey().
+   * @returns {Promise<Object>} Public key with x/y coordinates.
+   */
+  static async parseSpkiPublicKey(spki) {
+    const key = await crypto.subtle.importKey(
+      'spki',
+      spki instanceof Uint8Array ? spki.buffer : spki,
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      true,
+      ['verify']
+    );
+    const jwk = await crypto.subtle.exportKey('jwk', key);
+
+    const x = new Uint8Array(WebAuthnDIDProvider.base64urlToArrayBuffer(jwk.x));
+    const y = new Uint8Array(WebAuthnDIDProvider.base64urlToArrayBuffer(jwk.y));
+
+    if (x.length !== 32 || y.length !== 32) {
+      throw new WebAuthnCredentialError(
+        `Invalid P-256 coordinate length: x=${x.length} y=${y.length}`
+      );
+    }
+
+    return { algorithm: -7, x, y, keyType: 2, curve: 1 };
+  }
+
+  /**
+   * Parse the attested credential public key out of a WebAuthn attestation
+   * object (COSE key inside authenticatorData).
+   *
+   * See WebAuthn L2 §6.5.2 for the attestedCredentialData layout:
+   *   rpIdHash(32) | flags(1) | signCount(4) | aaguid(16) |
+   *   credentialIdLength(2) | credentialId(L) | credentialPublicKey(COSE) |
+   *   extensions(CBOR, optional)
+   *
+   * @param {ArrayBuffer|Uint8Array} attestationObjectBytes - Raw attestation object.
+   * @returns {Promise<Object>} Public key with x/y coordinates.
+   */
+  static async parseAttestedCredentialPublicKey(attestationObjectBytes) {
+    const cbor = await import('cbor-web');
+    const cborApi = cbor.default ?? cbor;
+    const decode = cborApi.decode;
+    const decodeFirstSync = cborApi.decodeFirstSync;
+
+    if (typeof decode !== 'function') {
+      throw new WebAuthnCredentialError(
+        'CBOR decoder not available from cbor-web'
+      );
+    }
+
+    const attestationObject = decode(new Uint8Array(attestationObjectBytes));
+    const rawAuthData =
+      attestationObject instanceof Map
+        ? attestationObject.get('authData')
+        : attestationObject.authData;
+
+    if (!rawAuthData) {
+      throw new WebAuthnCredentialError(
+        'Attestation object contains no authData'
+      );
+    }
+
+    // cbor-web returns byte strings as views into the *enclosing* buffer, so
+    // authData.byteOffset is non-zero. Copy to a standalone buffer, otherwise
+    // every offset below silently reads the wrong bytes.
+    const authData = Uint8Array.from(rawAuthData);
+
+    const AAGUID_END = 32 + 1 + 4 + 16; // 53
+    const CREDENTIAL_DATA_START = AAGUID_END + 2; // 55
+
+    // AT flag (bit 6) must be set, otherwise there is no attested credential data
+    const flags = authData[32];
+    if ((flags & 0x40) === 0) {
+      throw new WebAuthnCredentialError(
+        'authData has no attested credential data (AT flag unset)'
+      );
+    }
+
+    if (authData.length < CREDENTIAL_DATA_START) {
+      throw new WebAuthnCredentialError(
+        `authData too short: ${authData.length} bytes`
+      );
+    }
+
+    const view = new DataView(
+      authData.buffer,
+      authData.byteOffset,
+      authData.byteLength
+    );
+    const credentialIdLength = view.getUint16(AAGUID_END);
+    const publicKeyDataStart = CREDENTIAL_DATA_START + credentialIdLength;
+
+    if (publicKeyDataStart >= authData.length) {
+      throw new WebAuthnCredentialError(
+        `credentialIdLength ${credentialIdLength} exceeds authData (${authData.length} bytes)`
+      );
+    }
+
+    const publicKeyData = authData.slice(publicKeyDataStart);
+
+    // When the ED flag is set, CBOR extension data trails the COSE key.
+    // decode() rejects trailing bytes, so decode only the first item.
+    let publicKeyObject;
+    if (typeof decodeFirstSync === 'function') {
+      publicKeyObject = decodeFirstSync(publicKeyData, {
+        extendedResults: true,
+      }).value;
+    } else {
+      publicKeyObject = decode(publicKeyData);
+    }
+
+    const get = (k) =>
+      publicKeyObject instanceof Map
+        ? publicKeyObject.get(k)
+        : publicKeyObject[k];
+
+    const keyType = get(1);
+    const algorithm = get(3);
+    const curve = get(-1);
+    const x = get(-2);
+    const y = get(-3);
+
+    if (keyType !== 2 || curve !== 1) {
+      throw new WebAuthnCredentialError(
+        `Unsupported COSE key: kty=${keyType} alg=${algorithm} crv=${curve} (expected P-256 EC2)`
+      );
+    }
+
+    const xBytes = new Uint8Array(x);
+    const yBytes = new Uint8Array(y);
+
+    if (xBytes.length !== 32 || yBytes.length !== 32) {
+      throw new WebAuthnCredentialError(
+        `Invalid P-256 coordinate length: x=${xBytes.length} y=${yBytes.length}`
+      );
+    }
+
+    return { algorithm, x: xBytes, y: yBytes, keyType, curve };
   }
 
   /**

--- a/tests/webauthn-attestation-parsing.test.js
+++ b/tests/webauthn-attestation-parsing.test.js
@@ -1,0 +1,232 @@
+import { test, expect } from '@playwright/test';
+import cborModule from 'cbor-web';
+import { WebAuthnDIDProvider } from '../src/webauthn/provider.js';
+
+const cbor = cborModule.default ?? cborModule;
+const { encode } = cbor;
+
+const X_FILL = 0x11;
+const Y_FILL = 0x22;
+
+/**
+ * Build authenticatorData exactly as an authenticator would (WebAuthn L2 §6.1):
+ * rpIdHash(32) | flags(1) | signCount(4) | aaguid(16) |
+ * credentialIdLength(2) | credentialId(L) | credentialPublicKey(COSE) | extensions?
+ */
+function buildAuthData({
+  credIdLen = 32,
+  withExtensions = false,
+  kty = 2,
+  alg = -7,
+  crv = 1,
+  xLen = 32,
+  yLen = 32,
+  setAtFlag = true,
+} = {}) {
+  const rpIdHash = new Uint8Array(32).fill(0xaa);
+  // UP(0x01) | UV(0x04) | AT(0x40) | ED(0x80)
+  let flagByte = 0x01 | 0x04;
+  if (setAtFlag) flagByte |= 0x40;
+  if (withExtensions) flagByte |= 0x80;
+
+  const flags = new Uint8Array([flagByte]);
+  const signCount = new Uint8Array([0, 0, 0, 1]);
+  const aaguid = new Uint8Array(16).fill(0xbb);
+  const credIdLenBytes = new Uint8Array(2);
+  new DataView(credIdLenBytes.buffer).setUint16(0, credIdLen);
+  const credId = new Uint8Array(credIdLen).fill(0xcc);
+
+  const coseKey = encode(
+    new Map([
+      [1, kty],
+      [3, alg],
+      [-1, crv],
+      [-2, Buffer.alloc(xLen, X_FILL)],
+      [-3, Buffer.alloc(yLen, Y_FILL)],
+    ])
+  );
+
+  const extensions = withExtensions
+    ? encode(new Map([['prf', new Map([['enabled', true]])]]))
+    : new Uint8Array(0);
+
+  const parts = [
+    rpIdHash,
+    flags,
+    signCount,
+    aaguid,
+    credIdLenBytes,
+    credId,
+    coseKey,
+    extensions,
+  ];
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+function buildAttestationObject(authData) {
+  return new Uint8Array(
+    encode(
+      new Map([
+        ['fmt', 'none'],
+        ['attStmt', new Map()],
+        ['authData', Buffer.from(authData)],
+      ])
+    )
+  );
+}
+
+/** A credential shaped like the browser's, minus getPublicKey(). */
+function makeCredential(attestationObject, credIdLen = 32) {
+  return {
+    rawId: new Uint8Array(credIdLen).fill(0xcc).buffer,
+    response: { attestationObject },
+  };
+}
+
+test.describe('WebAuthn attestation object parsing', () => {
+  test('extracts the real COSE public key from an attestation object', async () => {
+    const attestationObject = buildAttestationObject(buildAuthData());
+
+    const key =
+      await WebAuthnDIDProvider.parseAttestedCredentialPublicKey(
+        attestationObject
+      );
+
+    expect(key.keyType).toBe(2);
+    expect(key.algorithm).toBe(-7);
+    expect(key.curve).toBe(1);
+    expect(key.x).toHaveLength(32);
+    expect(key.y).toHaveLength(32);
+    // The coordinates must be the authenticator's, not a hash of anything else.
+    expect([...key.x].every((b) => b === X_FILL)).toBe(true);
+    expect([...key.y].every((b) => b === Y_FILL)).toBe(true);
+  });
+
+  // Regression: authData is a view into the enclosing CBOR buffer with a
+  // non-zero byteOffset. Reading credentialIdLength via authData.buffer without
+  // honouring that offset yielded 0xaaaa (rpIdHash filler) for every credential
+  // length, so the COSE slice was always empty and cbor threw "Insufficient
+  // data" — silently degrading every credential to the synthetic fallback.
+  for (const credIdLen of [16, 20, 32, 64, 128]) {
+    test(`survives the authData byteOffset with credentialId length ${credIdLen}`, async () => {
+      const attestationObject = buildAttestationObject(
+        buildAuthData({ credIdLen })
+      );
+
+      const key =
+        await WebAuthnDIDProvider.parseAttestedCredentialPublicKey(
+          attestationObject
+        );
+
+      expect([...key.x].every((b) => b === X_FILL)).toBe(true);
+      expect([...key.y].every((b) => b === Y_FILL)).toBe(true);
+    });
+  }
+
+  test('tolerates trailing CBOR extension data when the ED flag is set', async () => {
+    const attestationObject = buildAttestationObject(
+      buildAuthData({ withExtensions: true })
+    );
+
+    const key =
+      await WebAuthnDIDProvider.parseAttestedCredentialPublicKey(
+        attestationObject
+      );
+
+    expect([...key.x].every((b) => b === X_FILL)).toBe(true);
+    expect([...key.y].every((b) => b === Y_FILL)).toBe(true);
+  });
+
+  test('throws instead of guessing when attested credential data is absent', async () => {
+    const attestationObject = buildAttestationObject(
+      buildAuthData({ setAtFlag: false })
+    );
+
+    await expect(
+      WebAuthnDIDProvider.parseAttestedCredentialPublicKey(attestationObject)
+    ).rejects.toThrow(/AT flag unset/);
+  });
+
+  test('throws on a non-P-256 COSE key rather than returning garbage', async () => {
+    const attestationObject = buildAttestationObject(
+      buildAuthData({ kty: 1, alg: -8, crv: 6 })
+    );
+
+    await expect(
+      WebAuthnDIDProvider.parseAttestedCredentialPublicKey(attestationObject)
+    ).rejects.toThrow(/Unsupported COSE key/);
+  });
+
+  test('throws on truncated coordinates', async () => {
+    const attestationObject = buildAttestationObject(
+      buildAuthData({ xLen: 31 })
+    );
+
+    await expect(
+      WebAuthnDIDProvider.parseAttestedCredentialPublicKey(attestationObject)
+    ).rejects.toThrow(/Invalid P-256 coordinate length/);
+  });
+});
+
+test.describe('extractPublicKey end to end', () => {
+  test('returns the authenticator key, not the synthetic fallback', async () => {
+    const attestationObject = buildAttestationObject(buildAuthData());
+    const credential = makeCredential(attestationObject);
+
+    const key = await WebAuthnDIDProvider.extractPublicKey(credential);
+
+    expect(key.synthetic).toBeUndefined();
+    expect([...key.x].every((b) => b === X_FILL)).toBe(true);
+    expect([...key.y].every((b) => b === Y_FILL)).toBe(true);
+  });
+
+  test('marks the synthetic fallback so it cannot pass as a real key', async () => {
+    const credential = makeCredential(new Uint8Array([0x00, 0x01, 0x02]));
+
+    const key = await WebAuthnDIDProvider.extractPublicKey(credential);
+
+    expect(key.synthetic).toBe(true);
+    expect(key.x).toHaveLength(32);
+  });
+
+  test('derives a DID from the authenticator key that differs from the fallback DID', async () => {
+    const attestationObject = buildAttestationObject(buildAuthData());
+
+    const realKey = await WebAuthnDIDProvider.extractPublicKey(
+      makeCredential(attestationObject)
+    );
+    const fallbackKey = await WebAuthnDIDProvider.extractPublicKey(
+      makeCredential(new Uint8Array([0x00]))
+    );
+
+    const realDid = await WebAuthnDIDProvider.createDID({
+      publicKey: realKey,
+    });
+    const fallbackDid = await WebAuthnDIDProvider.createDID({
+      publicKey: fallbackKey,
+    });
+
+    expect(realDid).toMatch(/^did:key:z/);
+    expect(realDid).not.toBe(fallbackDid);
+  });
+
+  test('is deterministic across repeated extractions', async () => {
+    const attestationObject = buildAttestationObject(buildAuthData());
+
+    const first = await WebAuthnDIDProvider.extractPublicKey(
+      makeCredential(attestationObject)
+    );
+    const second = await WebAuthnDIDProvider.extractPublicKey(
+      makeCredential(attestationObject)
+    );
+
+    expect([...first.x]).toEqual([...second.x]);
+    expect([...first.y]).toEqual([...second.y]);
+  });
+});


### PR DESCRIPTION
Addresses the "Side note" in #18 — the `Insufficient data` warning on every run. It is a separate defect from the identity-hash instability that issue is about; that part is untouched here. Two-peer coverage for the main issue is in #20.

## The bug

`extractPublicKey()` never took its intended path. Not for some authenticators — for all of them.

`cbor-web` returns byte strings as views into the *enclosing* buffer, so `authData.byteOffset` is non-zero (30 in practice). The old code read `credentialIdLength` through `authData.buffer` without honouring that offset:

```js
const credentialIdLength = new DataView(authData.buffer, 32+1+4+16, 2).getUint16(0)
```

That reads bytes 53..54 of the *attestation object* instead of of `authData` — landing inside `rpIdHash`. Measured:

```
authData.length=164  byteOffset=30  bufferLen=194
true credentialIdLength                 = 32
credentialIdLength as read by this code = 43690   (0xaaaa, rpIdHash filler)
→ publicKeyDataStart = 55 + 43690 → slice() empty → cbor: "Insufficient data"
```

The `catch` swallowed it and returned a synthetic key derived from `SHA-256(credentialId)`.

## Why it went unnoticed

The fallback is deterministic, so everything that looked like a stability check stayed green. `'should generate deterministic DID from credential'` calls `createDID` twice on the *same* credential object, and the reload test compares the DID before/after — both pass with a fake key.

The key is not the authenticator's, so no authenticator signature can verify against it. Anything relying on that — signature verification against the DID, cross-device key agreement — was operating on a hash of the credential ID.

## Changes

- Prefer `response.getPublicKey()` (WebAuthn L2) and parse the SPKI via WebCrypto
- Fix the attestation parser: honour `byteOffset`, validate the AT flag, bounds-check `credentialIdLength`
- Use `decodeFirstSync(..., {extendedResults: true})` so trailing CBOR extension data no longer throws. With the ED flag set (PRF is requested by this package) a corrected parser would otherwise hit `Unexpected data: 0xa1`
- Split into `parseAttestedCredentialPublicKey()` and `parseSpkiPublicKey()` so both are directly testable
- Validate the COSE key rather than returning `undefined` coordinates
- Mark the fallback `synthetic: true` so it cannot pass as a real key

## Tests

New `tests/webauthn-attestation-parsing.test.js` — 14 cases building spec-shaped attestation objects: credential ID lengths 16/20/32/64/128, trailing extension data, missing AT flag, non-P-256 COSE keys, truncated coordinates, and that `extractPublicKey` returns a non-synthetic key.

```
with this fix:    14 passed
without the fix:  13 failed, 1 passed
```

Existing suites — `webauthn-focused`, `webauthn-unit`, `webauthn-verification`, `webauthn-integration`, `standalone-toolkit`: **39 passed**. The DID is now derived from the virtual authenticator's real key and remains stable across reload.

`webauthn-logging-e2e` fails, but identically with and without this change (`waitForSelector` timeout) — pre-existing, not a regression here.

## ⚠️ Breaking

Credentials now yield the authenticator's actual public key, so the derived `did:key` **changes** for anyone who registered against an affected version. Existing OrbitDB identities keyed on the old DID will not match.

Per maintainer: nothing is rolled out yet, so no migration path is needed — this only wants a version bump reflecting the break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
