### PR TITLE
test: two-peer OrbitDB replication with a WebAuthn identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,11 @@ jobs:
         env:
           CI: true
 
+      - name: Run two-peer replication tests
+        run: pnpm run test:two-peer
+        env:
+          CI: true
+
       - name: Upload test artifacts
         if: failure()
         uses: actions/upload-artifact@v7

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "validate-package": "npm pack --dry-run && echo 'Package validation successful'",
     "preversion": "npm run test:ci",
     "version": "git add -A",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push && git push --tags",
+    "test:two-peer": "playwright test tests/webauthn-two-peer-replication.test.js --project=chromium --reporter=line"
   },
   "keywords": [
     "orbitdb",
@@ -100,12 +101,15 @@
     "@ipld/dag-json": "^11.0.0",
     "@libp2p/gossipsub": "^16.0.3",
     "@libp2p/identify": "^4.1.8",
+    "@libp2p/tcp": "^11.0.22",
     "@libp2p/websockets": "^10.1.15",
     "@orbitdb/core": "^4.0.0",
     "@orbitdb/simple-encryption": "^0.0.2",
     "@playwright/test": "^1.55.0",
+    "blockstore-core": "^7.0.1",
     "blockstore-level": "^4.0.1",
     "chai": "^5.0.0",
+    "datastore-core": "^12.0.1",
     "datastore-level": "^13.0.1",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.1.8",
@@ -143,7 +147,8 @@
     "onlyBuiltDependencies": [
       "@ipshipyard/node-datachannel",
       "classic-level",
-      "esbuild"
+      "esbuild",
+      "node-datachannel"
     ]
   },
   "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@libp2p/identify':
         specifier: ^4.1.8
         version: 4.1.8
+      '@libp2p/tcp':
+        specifier: ^11.0.22
+        version: 11.0.22
       '@libp2p/websockets':
         specifier: ^10.1.15
         version: 10.1.15
@@ -90,12 +93,18 @@ importers:
       '@playwright/test':
         specifier: ^1.55.0
         version: 1.58.1
+      blockstore-core:
+        specifier: ^7.0.1
+        version: 7.0.1
       blockstore-level:
         specifier: ^4.0.1
         version: 4.0.1
       chai:
         specifier: ^5.0.0
         version: 5.3.3
+      datastore-core:
+        specifier: ^12.0.1
+        version: 12.0.1
       datastore-level:
         specifier: ^13.0.1
         version: 13.0.1
@@ -2304,9 +2313,6 @@ packages:
   it-length@3.0.9:
     resolution: {integrity: sha512-cPhRPzyulYqyL7x4sX4MOjG/xu3vvEIFAhJ1aCrtrnbfxloCOtejOONib5oC3Bz8tLL6b6ke6+YHu4Bm6HCG7A==}
 
-  it-map@3.1.4:
-    resolution: {integrity: sha512-QB9PYQdE9fUfpVFYfSxBIyvKynUCgblb143c+ktTK6ZuKSKkp7iH58uYFzagqcJ5HcqIfn1xbfaralHWam+3fg==}
-
   it-map@3.1.6:
     resolution: {integrity: sha512-wCix0FXImtIPIxhCnbz35RqWs00e/CReSZX9nZq1j46JcAzBBp57ob9/2l1WnDYEaUURIR8xCyg2NsWbOwBJFQ==}
 
@@ -2355,9 +2361,6 @@ packages:
 
   it-take@3.0.11:
     resolution: {integrity: sha512-zvoeEjLViGFyhYT5KNCgmcIH90Si8lCve4aTMvgej/ZQRfB9YzrcJW3UHIJjbQ9TiAnsT4vsWDImEFQNk5xmnA==}
-
-  it-take@3.0.9:
-    resolution: {integrity: sha512-XMeUbnjOcgrhFXPUqa7H0VIjYSV/BvyxxjCp76QHVAFDJw2LmR1SHxUFiqyGeobgzJr7P2ZwSRRJQGn4D2BVlA==}
 
   it-to-browser-readablestream@2.0.14:
     resolution: {integrity: sha512-YyTLGvX5ufvukf05ZQCBEQO0ZyFmI9gxOEZ5yO1oQCnAL8Zlwmep7ty8RN2qg27oe1eu/qBQG5P79qS59Az8HA==}
@@ -5978,11 +5981,11 @@ snapshots:
       interface-store: 8.0.0
       it-drain: 3.0.12
       it-filter: 3.1.6
-      it-map: 3.1.4
+      it-map: 3.1.6
       it-merge: 3.0.14
       it-pipe: 3.0.1
       it-sort: 3.0.9
-      it-take: 3.0.9
+      it-take: 3.0.11
 
   datastore-level@13.0.1:
     dependencies:
@@ -6725,10 +6728,6 @@ snapshots:
 
   it-length@3.0.9: {}
 
-  it-map@3.1.4:
-    dependencies:
-      it-peekable: 3.0.8
-
   it-map@3.1.6:
     dependencies:
       it-peekable: 3.0.8
@@ -6798,8 +6797,6 @@ snapshots:
   it-stream-types@2.0.2: {}
 
   it-take@3.0.11: {}
-
-  it-take@3.0.9: {}
 
   it-to-browser-readablestream@2.0.14:
     dependencies:

--- a/tests/helpers/mock-authenticator.js
+++ b/tests/helpers/mock-authenticator.js
@@ -1,0 +1,264 @@
+/**
+ * A software WebAuthn authenticator for Node-context tests.
+ *
+ * Models the parts that matter for identity stability:
+ * - a real P-256 keypair, so signatures actually verify
+ * - spec-shaped attestationObject (WebAuthn L2 §6.5.2)
+ * - a signature counter that increments on every assertion
+ * - randomised ECDSA signatures
+ *
+ * The last two are why a WebAuthn assertion can never be content-addressed
+ * reproducibly — see issue #18.
+ */
+import cborModule from 'cbor-web';
+
+const cbor = cborModule.default ?? cborModule;
+const { encode } = cbor;
+
+function concatBytes(parts) {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+function base64urlToBytes(value) {
+  const padded = value.replace(/-/g, '+').replace(/_/g, '/');
+  return new Uint8Array(Buffer.from(padded, 'base64'));
+}
+
+function bytesToBase64url(bytes) {
+  return Buffer.from(bytes)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
+async function sha256(bytes) {
+  return new Uint8Array(await crypto.subtle.digest('SHA-256', bytes));
+}
+
+/**
+ * Create a mock authenticator backed by a real P-256 keypair.
+ * @param {Object} [options]
+ * @param {string} [options.rpId] - Relying party id.
+ * @param {boolean} [options.exposeGetPublicKey] - Whether attestation responses
+ *   expose getPublicKey(). Set false to force attestation-object parsing.
+ * @returns {Promise<Object>} Authenticator handle with a `navigator` shim.
+ */
+export async function createMockAuthenticator({
+  rpId = 'localhost',
+  exposeGetPublicKey = true,
+  credentialIdLength = 32,
+} = {}) {
+  const keypair = await crypto.subtle.generateKey(
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['sign', 'verify']
+  );
+
+  const jwk = await crypto.subtle.exportKey('jwk', keypair.publicKey);
+  const x = base64urlToBytes(jwk.x);
+  const y = base64urlToBytes(jwk.y);
+  const spki = new Uint8Array(
+    await crypto.subtle.exportKey('spki', keypair.publicKey)
+  );
+
+  const credentialId = crypto.getRandomValues(
+    new Uint8Array(credentialIdLength)
+  );
+  const rpIdHash = await sha256(new TextEncoder().encode(rpId));
+
+  const state = { signCount: 0, assertions: 0, creations: 0 };
+
+  const coseKey = new Uint8Array(
+    encode(
+      new Map([
+        [1, 2], // kty: EC2
+        [3, -7], // alg: ES256
+        [-1, 1], // crv: P-256
+        [-2, Buffer.from(x)],
+        [-3, Buffer.from(y)],
+      ])
+    )
+  );
+
+  const buildAuthData = ({ includeAttestedCredential }) => {
+    const flagByte = includeAttestedCredential
+      ? 0x01 | 0x04 | 0x40 // UP | UV | AT
+      : 0x01 | 0x04; // UP | UV
+    const signCountBytes = new Uint8Array(4);
+    new DataView(signCountBytes.buffer).setUint32(0, state.signCount);
+
+    if (!includeAttestedCredential) {
+      return concatBytes([
+        rpIdHash,
+        new Uint8Array([flagByte]),
+        signCountBytes,
+      ]);
+    }
+
+    const credIdLen = new Uint8Array(2);
+    new DataView(credIdLen.buffer).setUint16(0, credentialId.length);
+
+    return concatBytes([
+      rpIdHash,
+      new Uint8Array([flagByte]),
+      signCountBytes,
+      new Uint8Array(16).fill(0), // aaguid
+      credIdLen,
+      credentialId,
+      coseKey,
+    ]);
+  };
+
+  const buildClientDataJSON = (type, challenge) =>
+    new TextEncoder().encode(
+      JSON.stringify({
+        type,
+        challenge: bytesToBase64url(new Uint8Array(challenge)),
+        origin: `https://${rpId}`,
+        crossOrigin: false,
+      })
+    );
+
+  const navigatorShim = {
+    credentials: {
+      async create(options) {
+        state.creations += 1;
+        state.signCount += 1;
+
+        const challenge = options?.publicKey?.challenge ?? new Uint8Array(32);
+        const authData = buildAuthData({ includeAttestedCredential: true });
+        const attestationObject = new Uint8Array(
+          encode(
+            new Map([
+              ['fmt', 'none'],
+              ['attStmt', new Map()],
+              ['authData', Buffer.from(authData)],
+            ])
+          )
+        );
+
+        const response = {
+          attestationObject: attestationObject.buffer.slice(
+            attestationObject.byteOffset,
+            attestationObject.byteOffset + attestationObject.byteLength
+          ),
+          clientDataJSON: buildClientDataJSON('webauthn.create', challenge)
+            .buffer,
+        };
+
+        if (exposeGetPublicKey) {
+          response.getPublicKey = () =>
+            spki.buffer.slice(
+              spki.byteOffset,
+              spki.byteOffset + spki.byteLength
+            );
+        }
+
+        return {
+          id: bytesToBase64url(credentialId),
+          rawId: credentialId.buffer.slice(
+            credentialId.byteOffset,
+            credentialId.byteOffset + credentialId.byteLength
+          ),
+          type: 'public-key',
+          response,
+          getClientExtensionResults: () => ({}),
+        };
+      },
+
+      async get(options) {
+        state.assertions += 1;
+        state.signCount += 1; // a real authenticator always increments
+
+        const challenge = options?.publicKey?.challenge ?? new Uint8Array(32);
+        const authData = buildAuthData({ includeAttestedCredential: false });
+        const clientDataJSON = buildClientDataJSON('webauthn.get', challenge);
+        const clientDataHash = await sha256(clientDataJSON);
+
+        // ECDSA signatures are randomised: identical input, different output
+        const signature = new Uint8Array(
+          await crypto.subtle.sign(
+            { name: 'ECDSA', hash: 'SHA-256' },
+            keypair.privateKey,
+            concatBytes([authData, clientDataHash])
+          )
+        );
+
+        return {
+          id: bytesToBase64url(credentialId),
+          rawId: credentialId.buffer.slice(
+            credentialId.byteOffset,
+            credentialId.byteOffset + credentialId.byteLength
+          ),
+          type: 'public-key',
+          response: {
+            authenticatorData: authData.buffer.slice(
+              authData.byteOffset,
+              authData.byteOffset + authData.byteLength
+            ),
+            clientDataJSON: clientDataJSON.buffer,
+            signature: signature.buffer,
+            userHandle: null,
+          },
+          getClientExtensionResults: () => ({}),
+        };
+      },
+    },
+  };
+
+  return {
+    navigator: navigatorShim,
+    publicKey: { algorithm: -7, x, y, keyType: 2, curve: 1 },
+    credentialId,
+    state,
+  };
+}
+
+/**
+ * Install the mock on globalThis and return a restore function.
+ * @param {Object} authenticator - Result of createMockAuthenticator().
+ * @returns {Function} Restores the previous globals.
+ */
+export function installMockAuthenticator(authenticator) {
+  const previousNavigator = globalThis.navigator;
+  const previousWindow = globalThis.window;
+
+  Object.defineProperty(globalThis, 'navigator', {
+    value: authenticator.navigator,
+    configurable: true,
+    writable: true,
+  });
+
+  // isSupported() reads window.PublicKeyCredential, so the shim has to live
+  // on window, not just globalThis.
+  class MockPublicKeyCredential {
+    static isUserVerifyingPlatformAuthenticatorAvailable() {
+      return Promise.resolve(true);
+    }
+  }
+
+  globalThis.PublicKeyCredential = MockPublicKeyCredential;
+  globalThis.window = {
+    ...(previousWindow ?? {}),
+    location: { hostname: 'localhost', origin: 'https://localhost' },
+    navigator: authenticator.navigator,
+    PublicKeyCredential: MockPublicKeyCredential,
+  };
+
+  return () => {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: previousNavigator,
+      configurable: true,
+      writable: true,
+    });
+    globalThis.window = previousWindow;
+    delete globalThis.PublicKeyCredential;
+  };
+}

--- a/tests/helpers/two-peer.js
+++ b/tests/helpers/two-peer.js
@@ -1,0 +1,199 @@
+/**
+ * Two-peer OrbitDB harness for Node-context tests.
+ *
+ * Builds real libp2p + Helia + OrbitDB nodes over loopback TCP, so replication
+ * is exercised end to end rather than mocked.
+ */
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { withBitswap } from '@helia/bitswap';
+import { withLibp2p } from '@helia/libp2p';
+import { noise } from '@chainsafe/libp2p-noise';
+import { yamux } from '@chainsafe/libp2p-yamux';
+import * as dagCbor from '@ipld/dag-cbor';
+import { gossipsub } from '@libp2p/gossipsub';
+import { identify } from '@libp2p/identify';
+import { tcp } from '@libp2p/tcp';
+import { MemoryBlockstore } from 'blockstore-core';
+import { MemoryDatastore } from 'datastore-core';
+import { createHeliaLight } from 'helia';
+import { createLibp2p } from 'libp2p';
+import { sha512 } from 'multiformats/hashes/sha2';
+import {
+  createOrbitDB,
+  Identities,
+  KeyStore,
+  useIdentityProvider,
+} from '@orbitdb/core';
+
+import { OrbitDBWebAuthnIdentityProviderFunction } from '../../src/keystore/provider.js';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Silence the package's unconditional credential dumps for the duration of a
+ * test. logWebAuthnResponse() writes the full credential to console on every
+ * WebAuthn call, which floods CI output.
+ * @returns {Function} Restores console.
+ */
+export function silenceWebAuthnDebugLogging() {
+  const original = {
+    group: console.group,
+    groupEnd: console.groupEnd,
+    log: console.log,
+  };
+  let depth = 0;
+
+  console.group = (label) => {
+    if (typeof label === 'string' && label.startsWith('[WebAuthn Debug]')) {
+      depth += 1;
+      return;
+    }
+    original.group(label);
+  };
+  console.groupEnd = () => {
+    if (depth > 0) {
+      depth -= 1;
+      return;
+    }
+    original.groupEnd();
+  };
+  console.log = (...args) => {
+    if (depth > 0) return;
+    original.log(...args);
+  };
+
+  return () => {
+    console.group = original.group;
+    console.groupEnd = original.groupEnd;
+    console.log = original.log;
+  };
+}
+
+/**
+ * Create a started Helia node on loopback TCP with gossipsub.
+ * @param {Object} [options]
+ * @returns {Promise<Object>} Helia instance.
+ */
+export async function createPeer() {
+  const libp2p = await createLibp2p({
+    addresses: { listen: ['/ip4/127.0.0.1/tcp/0'] },
+    transports: [tcp()],
+    connectionEncrypters: [noise()],
+    streamMuxers: [yamux()],
+    services: {
+      identify: identify(),
+      pubsub: gossipsub({ allowPublishToZeroTopicPeers: true }),
+    },
+  });
+
+  // Helia 7 ignores init.libp2p — the instance has to be composed in.
+  const helia = await withBitswap(
+    withLibp2p(
+      createHeliaLight({
+        blockstore: new MemoryBlockstore(),
+        datastore: new MemoryDatastore(),
+        codecs: [dagCbor],
+        hashers: [sha512],
+      }),
+      libp2p
+    )
+  );
+
+  await helia.start();
+  return helia;
+}
+
+/**
+ * Dial `b` from `a` and wait until the connection is established.
+ * @param {Object} a - Dialing Helia node.
+ * @param {Object} b - Listening Helia node.
+ */
+export async function connectPeers(a, b) {
+  await a.libp2p.dial(b.libp2p.getMultiaddrs());
+  await waitFor(() => b.libp2p.getConnections().length > 0, 15000);
+}
+
+/**
+ * Build an OrbitDB instance backed by a WebAuthn identity.
+ *
+ * Calling this twice with the same keystorePath, directory and credential
+ * models a page reload: same keystore, same passkey, fresh Identities.
+ *
+ * @param {Object} params
+ * @returns {Promise<Object>} { orbitdb, identity, identities }
+ */
+export async function createOrbitForCredential({
+  helia,
+  credential,
+  keystorePath,
+  directory,
+  id,
+}) {
+  useIdentityProvider(OrbitDBWebAuthnIdentityProviderFunction);
+
+  const keystore = await KeyStore({ path: keystorePath });
+  const identities = await Identities({ ipfs: helia, keystore });
+  const identity = await identities.createIdentity({
+    provider: OrbitDBWebAuthnIdentityProviderFunction({
+      webauthnCredential: credential,
+    }),
+  });
+
+  const orbitdb = await createOrbitDB({
+    ipfs: helia,
+    identities,
+    identity,
+    directory,
+    id,
+  });
+
+  return { orbitdb, identity, identities, keystore };
+}
+
+/**
+ * Poll until `fn` is truthy or the timeout elapses.
+ * @param {Function} fn - Predicate, may be async.
+ * @param {number} timeoutMs - Timeout in ms.
+ * @param {number} [intervalMs] - Poll interval.
+ * @returns {Promise<boolean>} Whether the predicate became true.
+ */
+export async function waitFor(fn, timeoutMs, intervalMs = 250) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await fn()) return true;
+    await sleep(intervalMs);
+  }
+  return false;
+}
+
+/**
+ * Collect the values a database holds, polling until `expected` show up.
+ * @param {Object} db - OrbitDB events database.
+ * @param {number} expected - Number of distinct values to wait for.
+ * @param {number} timeoutMs - Timeout in ms.
+ * @returns {Promise<string[]>} Values seen.
+ */
+export async function collectValues(db, expected, timeoutMs) {
+  const seen = new Set();
+  await waitFor(async () => {
+    for (const entry of await db.all()) seen.add(entry.value);
+    return seen.size >= expected;
+  }, timeoutMs);
+  return [...seen];
+}
+
+/**
+ * Create a scratch directory that is removed on cleanup.
+ * @returns {Promise<Object>} { path, cleanup }
+ */
+export async function scratchDir() {
+  const path = await mkdtemp(join(tmpdir(), 'webauthn-two-peer-'));
+  return {
+    path,
+    sub: (name) => join(path, name),
+    cleanup: () => rm(path, { recursive: true, force: true }),
+  };
+}

--- a/tests/webauthn-two-peer-replication.test.js
+++ b/tests/webauthn-two-peer-replication.test.js
@@ -1,0 +1,220 @@
+/**
+ * Two-peer OrbitDB replication with a WebAuthn identity.
+ *
+ * The suite this repo previously had never opened a second peer and never
+ * looked at an identity hash, so the failure mode described in issue #18 —
+ * a database that replicates some entries and silently drops the rest —
+ * had no coverage at all.
+ *
+ * Tests marked `test.fail()` pin the open bug. When it is fixed they will
+ * start passing and Playwright will report "expected to fail but passed",
+ * which is the signal to drop the annotation.
+ */
+import { test, expect } from '@playwright/test';
+
+import {
+  createMockAuthenticator,
+  installMockAuthenticator,
+} from './helpers/mock-authenticator.js';
+import {
+  collectValues,
+  connectPeers,
+  createOrbitForCredential,
+  createPeer,
+  scratchDir,
+  silenceWebAuthnDebugLogging,
+} from './helpers/two-peer.js';
+
+const REPLICATION_TIMEOUT = 25000;
+
+test.describe('WebAuthn identity across two OrbitDB peers', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let restoreAuthenticator;
+  let restoreLogging;
+  let scratch;
+  let credential;
+  let alice;
+  let bob;
+
+  test.beforeEach(async () => {
+    test.setTimeout(120000);
+
+    restoreLogging = silenceWebAuthnDebugLogging();
+    const authenticator = await createMockAuthenticator();
+    restoreAuthenticator = installMockAuthenticator(authenticator);
+    scratch = await scratchDir();
+
+    const { WebAuthnDIDProvider } = await import('../src/webauthn/provider.js');
+    credential = await WebAuthnDIDProvider.createCredential({
+      userId: 'two-peer-user',
+      displayName: 'Two Peer User',
+    });
+
+    alice = await createPeer();
+    bob = await createPeer();
+    await connectPeers(bob, alice);
+  });
+
+  test.afterEach(async () => {
+    await bob?.stop();
+    await alice?.stop();
+    await scratch?.cleanup();
+    restoreAuthenticator?.();
+    restoreLogging?.();
+  });
+
+  const openAlice = (label) =>
+    createOrbitForCredential({
+      helia: alice,
+      credential,
+      keystorePath: scratch.sub('alice-keys'),
+      directory: scratch.sub('alice-orbit'),
+      id: label,
+    });
+
+  const openBob = () =>
+    createOrbitForCredential({
+      helia: bob,
+      credential,
+      keystorePath: scratch.sub('bob-keys'),
+      directory: scratch.sub('bob-orbit'),
+      id: 'bob',
+    });
+
+  test('peers are connected and share a pubsub-capable libp2p', async () => {
+    expect(alice.libp2p.getConnections().length).toBeGreaterThan(0);
+    expect(bob.libp2p.getConnections().length).toBeGreaterThan(0);
+    expect(alice.libp2p.services.pubsub).toBeTruthy();
+  });
+
+  test('replicates entries written under a single identity document', async () => {
+    const a = await openAlice('alice');
+    const db = await a.orbitdb.open('single-identity', { type: 'events' });
+    await db.add('entry-1');
+    await db.add('entry-2');
+
+    const b = await openBob();
+    const dbB = await b.orbitdb.open(db.address, { type: 'events' });
+
+    const seen = await collectValues(dbB, 2, REPLICATION_TIMEOUT);
+    expect(seen.sort()).toEqual(['entry-1', 'entry-2']);
+
+    await dbB.close();
+    await b.orbitdb.stop();
+    await db.close();
+    await a.orbitdb.stop();
+  });
+
+  test('the remote peer can resolve identity documents over bitswap', async () => {
+    const a = await openAlice('alice');
+    const db = await a.orbitdb.open('identity-resolution', { type: 'events' });
+    await db.add('entry-1');
+
+    const b = await openBob();
+    const dbB = await b.orbitdb.open(db.address, { type: 'events' });
+    await collectValues(dbB, 1, REPLICATION_TIMEOUT);
+
+    // Identities are plain IPFS blocks fetched on demand — not replicated
+    // through any OrbitDB database.
+    const resolved = await b.identities.getIdentity(a.identity.hash);
+    expect(resolved).toBeTruthy();
+    expect(resolved.id).toBe(a.identity.id);
+
+    await dbB.close();
+    await b.orbitdb.stop();
+    await db.close();
+    await a.orbitdb.stop();
+  });
+
+  // ---------------------------------------------------------------------
+  // Issue #18
+  // ---------------------------------------------------------------------
+
+  test.fail('identity hash is stable across reloads (issue #18)', async () => {
+    const first = await openAlice('alice');
+    await first.orbitdb.stop();
+
+    const second = await openAlice('alice');
+    await second.orbitdb.stop();
+
+    // The DID and the keypair are stable; only the document hash moves,
+    // because signIdentity() performs a live WebAuthn assertion whose
+    // result is embedded in the content-addressed document.
+    expect(second.identity.id).toBe(first.identity.id);
+    expect(second.identity.publicKey).toBe(first.identity.publicKey);
+    expect(second.identity.signatures.id).toBe(first.identity.signatures.id);
+
+    expect(second.identity.hash).toBe(first.identity.hash);
+  });
+
+  test.fail(
+    'entries written before and after a reload both replicate (issue #18)',
+    async () => {
+      const load1 = await openAlice('alice');
+      const db1 = await load1.orbitdb.open('reload-test', { type: 'events' });
+      const address = db1.address;
+      await db1.add('entry-1-before-reload');
+      await db1.close();
+      await load1.orbitdb.stop();
+
+      // page reload: same keystore, same passkey, fresh Identities
+      const load2 = await openAlice('alice');
+      const db2 = await load2.orbitdb.open(address, { type: 'events' });
+      await db2.add('entry-2-after-reload');
+
+      expect((await db2.all()).length).toBe(2);
+
+      const b = await openBob();
+      const dbB = await b.orbitdb.open(address, { type: 'events' });
+      const seen = await collectValues(dbB, 2, REPLICATION_TIMEOUT);
+
+      await dbB.close();
+      await b.orbitdb.stop();
+      await db2.close();
+      await load2.orbitdb.stop();
+
+      // Today bob receives only whichever entry was signed by the identity
+      // document he happened to verify first.
+      expect(seen.sort()).toEqual([
+        'entry-1-before-reload',
+        'entry-2-after-reload',
+      ]);
+    }
+  );
+
+  test.fail(
+    'a second identity document from the same DID still verifies (issue #18)',
+    async () => {
+      // One load at a time — the keystore holds an exclusive lock.
+      const load1 = await openAlice('alice');
+      const hash1 = load1.identity.hash;
+      await load1.orbitdb.stop();
+
+      const load2 = await openAlice('alice');
+      const hash2 = load2.identity.hash;
+
+      const b = await openBob();
+
+      // Both documents are retrievable — resolution is not the problem.
+      const doc1 = await b.identities.getIdentity(hash1);
+      const doc2 = await b.identities.getIdentity(hash2);
+      expect(doc1).toBeTruthy();
+      expect(doc2).toBeTruthy();
+
+      // signatures.id is deterministic, so both documents collide on the key
+      // of verifiedIdentitiesCache in @orbitdb/core identities.js. The first
+      // document verified wins; isEqual() then rejects every later document
+      // because signatures.publicKey differs.
+      expect(doc1.signatures.id).toBe(doc2.signatures.id);
+      expect(doc1.publicKey).toBe(doc2.publicKey);
+      expect(doc1.signatures.publicKey).not.toBe(doc2.signatures.publicKey);
+
+      expect(await b.identities.verifyIdentity(doc1)).toBe(true);
+      expect(await b.identities.verifyIdentity(doc2)).toBe(true);
+
+      await b.orbitdb.stop();
+      await load2.orbitdb.stop();
+    }
+  );
+});


### PR DESCRIPTION
Adds the two-peer coverage this repo never had, and pins #18 with executable tests.

Independent of #19 — based on `main`, verified green there.

## Why

There was no second peer anywhere in `tests/`, `identity.hash` appeared in no test, and `createOrbitDB` was never called directly — every test drives the demo UI. The one test whose name suggests otherwise, `'should work across different browser contexts'` (`webauthn-integration.test.js:330`), opens a single context, reads `localStorage`, and closes. Its comment claims DIDs are consistent across sessions; nothing asserts that.

So the failure mode in #18 — a database that replicates some entries and silently drops the rest — had no coverage at all.

## What this adds

A Node-context harness (`tests/helpers/two-peer.js`): real libp2p over loopback TCP, Helia with bitswap, gossipsub, two OrbitDB instances. Plus a software WebAuthn authenticator (`tests/helpers/mock-authenticator.js`) that models what actually matters — a real P-256 keypair so signatures verify, a spec-shaped attestation object, an incrementing signature counter, and randomised ECDSA signatures.

Calling `createOrbitForCredential()` twice with the same keystore path, directory and credential models a page reload.

**Passing today** (guard the harness and a real invariant):
- peers connect and expose a pubsub-capable libp2p
- entries written under a single identity document replicate
- the remote peer resolves identity documents over bitswap — confirming identities travel as plain IPFS blocks fetched on demand, *not* through any OrbitDB database

**Marked `test.fail()`, pinning #18:**
- identity hash is stable across reloads
- entries written before and after a reload both replicate
- a second identity document from the same DID still verifies

`test.fail()` means Playwright reports "expected to fail but passed" once the bug is fixed — the signal to drop the annotation. Each was verified to fail on its own assertion, not on setup.

## The root cause is narrower than #18 assumes

#18 attributes the drop to a peer that "cannot resolve that exact document". Measured on the receiving peer:

```
bob resolve H1 (load1): FOUND
bob resolve H2 (load2): FOUND

same signatures.id?        true    <- cache key
same publicKey?            true
same signatures.publicKey? false

verifyIdentity(H1): true
verifyIdentity(H2): false         <- second doc, same cache key
```

Both documents resolve. The rejection comes from `verifiedIdentitiesCache` in `@orbitdb/core` `identities.js:118`, which is keyed on `signatures.id`. That value is `signMessage(privateKey, id)` — deterministic for a given keystore key. So every identity document from the same DID collides on one cache entry:

```js
const verifiedIdentity = await verifiedIdentitiesCache.get(signatures.id)
if (verifiedIdentity) {
  return isEqual(identity, verifiedIdentity)   // compares hash + signatures.publicKey
}
```

The first document verified wins; `isEqual` then rejects every later one because `hash` and `signatures.publicKey` differ. `canAppend` returns false and the entry is dropped as `Key "<hash>" is not allowed to write to the log`.

This explains the asymmetry reported in #18 exactly — one database replicating while another from the same writer over the same connection does not depends purely on which page load's document that peer happened to verify first. It also means the workaround in #18 (remember the first hash and reuse it) works for the right reason, and that a fix has to make the document reproducible; caching alone will not do it.

## Notes

- Helia 7 ignores `init.libp2p`, so the node is composed as `withBitswap(withLibp2p(createHeliaLight(...), libp2p))`. Passing `libp2p` to `createHelia` silently yields Helia's own defaults with no pubsub.
- `node-datachannel` added to `pnpm.onlyBuiltDependencies` — `@helia/libp2p` pulls `@libp2p/webrtc`, and without its install script the module fails to load in Node. It resolves to a prebuilt binary, no compile.
- New devDeps: `@libp2p/tcp`, `blockstore-core`, `datastore-core`.
- Run with `pnpm run test:two-peer`.
- The tests silence `logWebAuthnResponse()`, which unconditionally `console.log`s the full credential on every WebAuthn call. Worth addressing separately — it floods output and dumps credential material into the browser console in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
