### PR TITLE
ci: run the five test files that were never wired up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,37 @@ jobs:
         env:
           CI: true
 
+      - name: Run WebAuthn unit tests
+        # This suite imports src/index.js through Vite's /@fs endpoint, which
+        # only the dev server exposes. playwright.config.js starts `preview`
+        # when CI is set, and that build has no such route, so this step has to
+        # run against the dev server — hence the cleared CI variable.
+        run: pnpm exec playwright test tests/webauthn-unit.test.js --project=chromium --reporter=github
+        env:
+          CI: ''
+
+      - name: Run WebAuthn verification tests
+        run: pnpm exec playwright test tests/webauthn-verification.test.js --project=chromium --reporter=github
+        env:
+          CI: true
+
+      - name: Run standalone toolkit tests
+        run: pnpm exec playwright test tests/standalone-toolkit.test.js --project=chromium --reporter=github
+        env:
+          CI: true
+
+      - name: Run Ed25519 keystore DID tests
+        run: pnpm exec playwright test tests/ed25519-keystore-did.test.js --project=chromium --reporter=github
+        env:
+          CI: true
+          USE_ENCRYPTED_DEMO: true
+
+      - name: Run simple encryption integration tests
+        run: pnpm exec playwright test tests/simple-encryption-integration.test.js --project=chromium --reporter=github
+        env:
+          CI: true
+          USE_ENCRYPTED_DEMO: true
+
       - name: Upload test artifacts
         if: failure()
         uses: actions/upload-artifact@v7

--- a/tests/ed25519-keystore-did.test.js
+++ b/tests/ed25519-keystore-did.test.js
@@ -5,13 +5,12 @@ const authenticateButton = 'button:has-text("Authenticate with WebAuthn")';
 
 async function openSecurityOptions(page) {
   await page.goto('http://localhost:5173', { waitUntil: 'domcontentloaded' });
-  if (
-    await page
-      .getByText('TODO List')
-      .isVisible({ timeout: 2000 })
-      .catch(() => false)
-  ) {
-    await page.click('button:has-text("Logout")');
+  // Gate on the Logout button itself rather than on the "TODO List" heading.
+  // Against the production build the heading paints before the button is
+  // interactive, so keying off the heading raced and timed out on the click.
+  const logoutButton = page.locator('button:has-text("Logout")');
+  if (await logoutButton.isVisible({ timeout: 5000 }).catch(() => false)) {
+    await logoutButton.click();
     await page.waitForTimeout(300);
   }
   const hasCreateButton = await page
@@ -164,8 +163,11 @@ test.describe('Ed25519 Keystore DID Feature', () => {
     const useKeystoreIdentity = page.getByLabel(
       /Use persistent keystore identity/i
     );
-    const secpKeyOption = page.getByLabel('secp256k1');
-    const ed25519KeyOption = page.getByLabel('Ed25519');
+    // Scope to the radio group: the worker-mode checkbox is labelled
+    // "Use worker-backed Ed25519 keystore", so a plain getByLabel('Ed25519')
+    // matches two controls.
+    const secpKeyOption = page.getByRole('radio', { name: /secp256k1/ });
+    const ed25519KeyOption = page.getByRole('radio', { name: /Ed25519/ });
 
     await expect(secpKeyOption).toBeVisible();
     await expect(ed25519KeyOption).toBeVisible();


### PR DESCRIPTION
Follow-up to the test-coverage audit in #18. Independent of #19 and #20 — based on `main`.

## What was missing

Of eleven test files, **five never ran in CI** — 37 tests written, maintained, and never executed:

| File | Tests | Ran unchanged? |
|---|---|---|
| `webauthn-verification` | 5 | ✅ |
| `standalone-toolkit` | 11 | ✅ |
| `simple-encryption-integration` | 4 | ✅ |
| `webauthn-unit` | 10 | ❌ incompatible with the CI server |
| `ed25519-keystore-did` | 6 | ❌ two failures |

I initially assumed all five were simply forgotten. Two of them genuinely could not run as the workflow is written, which is presumably why they stayed out. Both are addressed here.

## 1. `webauthn-unit` — incompatible with the CI web server

Its `beforeEach` loads the package through Vite's `/@fs` endpoint:

```js
const moduleUrl = `/@fs${process.cwd().replace(/\\/g, '/')}/src/index.js`;
```

`/@fs` is a **dev-server-only** route. `playwright.config.js` starts `preview` whenever `CI` is set, and the static build has no such endpoint, so every test in the file fails:

```
TypeError: Failed to fetch dynamically imported module:
http://localhost:5173/@fs/<cwd>/src/index.js
```

Reproduced locally with `CI=true`, matching the CI log exactly.

Its step therefore clears `CI` so the dev server is used. Rewriting the suite to drop the `/@fs` import would be the cleaner fix — the whole file depends on it via `window.WebAuthnModule` — but that is a bigger change than wiring up CI, so I've left it. Happy to do it separately if you'd prefer.

## 2. `ed25519-keystore-did` — two failures

**Strict mode violation** in `'shows key type controls only when persistent identity is enabled'`:

```
getByLabel('Ed25519') resolved to 2 elements:
    1) <input type="radio" value="Ed25519"/>
    2) <input type="checkbox" data-testid="worker-mode-toggle"/>
```

`getByLabel` matches substrings, and the worker-mode toggle added to the demo is labelled *"Use worker-backed Ed25519 keystore"*. Both key-type locators are now scoped to the radio role.

**Timeout** in `'produces different DIDs for WebAuthn identity vs Ed25519 keystore identity'` — and this one only appears against the production build, so the dev server hid it. `openSecurityOptions()` gated on the "TODO List" heading and then clicked Logout:

```js
if (await page.getByText('TODO List').isVisible({ timeout: 2000 }).catch(() => false)) {
  await page.click('button:has-text("Logout")');
```

Under `preview` the heading paints before the button is interactive, so the click waited out its 30s. It now gates on the button itself — which also cuts the file from 2.1 minutes to 12 seconds.

Assertions are unchanged throughout; only locators and waiting moved.

## Verification

Each suite run locally in the exact mode its CI step uses:

```
webauthn-unit                  (CI='')      10 passed
webauthn-verification          (CI=true)     5 passed
standalone-toolkit             (CI=true)    11 passed
ed25519-keystore-did           (CI=true)     6 passed
simple-encryption-integration  (CI=true)     4 passed
```

`lint` and `format:check` clean. The first push of this branch failed CI on exactly the `webauthn-unit` issue above — that is what surfaced it.

## Worth flagging separately

`test:ci` is `playwright test tests/webauthn-verification.test.js` — five tests. Since `prepublishOnly` and `preversion` both run `test:ci`, **every release so far was gated on those five tests alone**, which did not run in the pipeline either. This PR adds a direct step for that file and leaves the script alone, but pointing `test:ci` at the full suite is probably the right follow-up.

Both demos are already installed and built by the existing workflow, so the new steps need no extra setup; the two encrypted-demo suites just get `USE_ENCRYPTED_DEMO: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
