### PR TITLE
fix: keep the identity document stable across reloads (closes #18)

### DIFF
--- a/src/keystore/provider.js
+++ b/src/keystore/provider.js
@@ -9,6 +9,11 @@ import { base58btc } from 'multiformats/bases/base58';
 import * as KeystoreEncryption from './encryption.js';
 import { WebAuthnDIDProvider } from '../webauthn/provider.js';
 import {
+  identityProofKey,
+  loadIdentityProof,
+  storeIdentityProof,
+} from '../webauthn/identity-proof-store.js';
+import {
   DID_KEY_PREFIX,
   IDENTITY_TYPES,
   KEYSTORE_ENCRYPTION_METHODS,
@@ -520,10 +525,18 @@ export class OrbitDBWebAuthnIdentityProvider {
 
   /**
    * Sign data for OrbitDB identity operations.
+   *
+   * The result becomes `signatures.publicKey` in the identity document, which
+   * OrbitDB content-addresses. A fresh WebAuthn assertion here would change
+   * the document hash on every page load, and peers reject entries signed
+   * under any document but the first one they verified (issue #18). The proof
+   * is therefore stored under the payload it covers and reused; the assertion
+   * happens once, when the identity is first established.
+   *
    * @param {string|Uint8Array} data - Payload to sign.
    * @returns {Promise<string>} Signature envelope.
    */
-  signIdentity(data) {
+  async signIdentity(data) {
     const dataLength = typeof data === 'string' ? data.length : data.byteLength;
     identityLog('signIdentity() called with data length: %d', dataLength);
     identityLog('Signer context: %o', {
@@ -540,7 +553,19 @@ export class OrbitDBWebAuthnIdentityProvider {
       );
     }
 
-    return this.webauthnProvider.sign(data);
+    const proofKey = await identityProofKey(this.credential.credentialId, data);
+    const stored = loadIdentityProof(proofKey);
+    if (stored) {
+      identityLog(
+        'Reusing stored identity proof, so the identity document stays stable'
+      );
+      return stored;
+    }
+
+    identityLog('No stored identity proof; requesting a WebAuthn assertion');
+    const proof = await this.webauthnProvider.sign(data);
+    storeIdentityProof(proofKey, proof);
+    return proof;
   }
 
   /**

--- a/src/webauthn/identity-proof-store.js
+++ b/src/webauthn/identity-proof-store.js
@@ -1,0 +1,130 @@
+/**
+ * @module IdentityProofStore
+ * @description
+ * Persists the WebAuthn proof that becomes `signatures.publicKey` in an
+ * OrbitDB identity document.
+ *
+ * OrbitDB content-addresses the identity document, so its hash is only stable
+ * if every field is. A WebAuthn assertion is deliberately non-deterministic —
+ * randomised ECDSA, an incrementing signature counter — so re-signing on every
+ * page load mints a new document each time, and peers reject entries signed
+ * under any document but the first one they verified.
+ *
+ * The proof attests that this credential signed this exact payload. That
+ * statement does not change between page loads, so the proof is stored under
+ * the payload it covers and reused. The assertion still happens once, when the
+ * identity is first established.
+ *
+ * See issue #18.
+ */
+import { logger } from '@libp2p/logger';
+
+const log = logger('orbitdb-identity-provider-webauthn-did:identity-proof');
+
+const STORAGE_PREFIX = 'webauthn-identity-proof:';
+
+// Used when no Web Storage is available (Node, SSR, private-mode failures).
+// Process-lifetime only, which still keeps a single run self-consistent.
+const memoryStore = new Map();
+
+/**
+ * The Storage to use, or null when none is usable.
+ * @returns {Storage|null} A Web Storage implementation.
+ */
+function getStorage() {
+  try {
+    const storage = globalThis.localStorage;
+    if (!storage) return null;
+    // Safari in private mode throws on write rather than on access.
+    const probe = `${STORAGE_PREFIX}probe`;
+    storage.setItem(probe, '1');
+    storage.removeItem(probe);
+    return storage;
+  } catch {
+    return null;
+  }
+}
+
+function toBase64url(bytes) {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+/**
+ * Derive the storage key for a proof.
+ *
+ * Keyed by credential and payload together, so a different passkey on the same
+ * origin cannot pick up another credential's proof.
+ *
+ * @param {string} credentialId - Base64url credential id.
+ * @param {string|Uint8Array} data - Payload passed to signIdentity().
+ * @returns {Promise<string>} Storage key.
+ */
+export async function identityProofKey(credentialId, data) {
+  const payload =
+    typeof data === 'string' ? new TextEncoder().encode(data) : data;
+  const credential = new TextEncoder().encode(String(credentialId));
+
+  const combined = new Uint8Array(credential.length + 1 + payload.length);
+  combined.set(credential, 0);
+  combined[credential.length] = 0x1f; // separator, so the join is unambiguous
+  combined.set(payload, credential.length + 1);
+
+  const digest = await crypto.subtle.digest('SHA-256', combined);
+  return STORAGE_PREFIX + toBase64url(new Uint8Array(digest));
+}
+
+/**
+ * Look up a previously stored proof.
+ * @param {string} key - Key from identityProofKey().
+ * @returns {string|null} The proof, or null.
+ */
+export function loadIdentityProof(key) {
+  const storage = getStorage();
+  if (storage) {
+    const value = storage.getItem(key);
+    if (value) return value;
+  }
+  return memoryStore.get(key) ?? null;
+}
+
+/**
+ * Store a proof for reuse on later loads.
+ * @param {string} key - Key from identityProofKey().
+ * @param {string} proof - The proof envelope.
+ */
+export function storeIdentityProof(key, proof) {
+  memoryStore.set(key, proof);
+
+  const storage = getStorage();
+  if (!storage) {
+    log(
+      'no Web Storage available; identity proof kept in memory only, so the identity document will change after a reload'
+    );
+    return;
+  }
+
+  try {
+    storage.setItem(key, proof);
+  } catch (error) {
+    log.error('failed to persist identity proof: %s', error.message);
+  }
+}
+
+/**
+ * Drop every stored proof. Intended for logout and for tests.
+ */
+export function clearIdentityProofs() {
+  memoryStore.clear();
+
+  const storage = getStorage();
+  if (!storage) return;
+
+  const keys = [];
+  for (let i = 0; i < storage.length; i++) {
+    const key = storage.key(i);
+    if (key?.startsWith(STORAGE_PREFIX)) keys.push(key);
+  }
+  for (const key of keys) storage.removeItem(key);
+}

--- a/src/webauthn/provider.js
+++ b/src/webauthn/provider.js
@@ -559,13 +559,14 @@ export class WebAuthnDIDProvider {
         signature: WebAuthnDIDProvider.arrayBufferToBase64url(
           assertion.response.signature
         ),
-        timestamp: Date.now(),
+        // Deliberately no timestamp. This envelope ends up in a
+        // content-addressed identity document, so a wall-clock field would
+        // change the document hash on every call for no verification value.
       };
 
       webauthnLog('Proof created successfully: %o', {
         credentialId: webauthnProof.credentialId.substring(0, 16) + '...',
         dataHash: webauthnProof.dataHash.substring(0, 16) + '...',
-        timestamp: webauthnProof.timestamp,
       });
 
       // Return the proof as a base64url encoded string for OrbitDB
@@ -644,18 +645,12 @@ export class WebAuthnDIDProvider {
         throw new WebAuthnVerificationError('Invalid client data');
       }
 
-      // Check if proof is recent (within 24 hours)
-      webauthnLog('Verification step: checking timestamp');
-      const proofAge = Date.now() - proof.timestamp;
-      const maxAge = 24 * 60 * 60 * 1000; // 24 hours
-      if (proofAge > maxAge) {
-        webauthnLog.error('WebAuthn proof is too old: %d ms', proofAge);
-        throw new WebAuthnVerificationError('WebAuthn proof has expired');
-      }
-      webauthnLog(
-        'Verification step: timestamp check PASSED (age: %d ms)',
-        proofAge
-      );
+      // No expiry check. This proof is embedded in an OrbitDB identity
+      // document, and every entry ever signed under that document has to stay
+      // validatable — an expiring proof would silently invalidate history.
+      // The proof attests that this credential signed this payload, which does
+      // not stop being true. Proofs written by earlier versions still carry a
+      // timestamp field; it is simply ignored.
 
       // Verify authenticator data exists
       webauthnLog('Verification step: checking authenticator data');

--- a/tests/helpers/mock-authenticator.js
+++ b/tests/helpers/mock-authenticator.js
@@ -229,6 +229,21 @@ export async function createMockAuthenticator({
 export function installMockAuthenticator(authenticator) {
   const previousNavigator = globalThis.navigator;
   const previousWindow = globalThis.window;
+  const previousLocalStorage = globalThis.localStorage;
+
+  // Browser storage survives a page reload, so this shim has to outlive the
+  // simulated reloads within one test rather than being recreated per load.
+  const store = new Map();
+  globalThis.localStorage = {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+    clear: () => store.clear(),
+    key: (i) => [...store.keys()][i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
 
   Object.defineProperty(globalThis, 'navigator', {
     value: authenticator.navigator,
@@ -259,6 +274,7 @@ export function installMockAuthenticator(authenticator) {
       writable: true,
     });
     globalThis.window = previousWindow;
+    globalThis.localStorage = previousLocalStorage;
     delete globalThis.PublicKeyCredential;
   };
 }

--- a/tests/webauthn-two-peer-replication.test.js
+++ b/tests/webauthn-two-peer-replication.test.js
@@ -6,9 +6,8 @@
  * a database that replicates some entries and silently drops the rest —
  * had no coverage at all.
  *
- * Tests marked `test.fail()` pin the open bug. When it is fixed they will
- * start passing and Playwright will report "expected to fail but passed",
- * which is the signal to drop the annotation.
+ * The issue #18 cases below were introduced as `test.fail()` and flipped once
+ * signIdentity() started reusing a stored proof. They now guard the fix.
  */
 import { test, expect } from '@playwright/test';
 
@@ -131,16 +130,16 @@ test.describe('WebAuthn identity across two OrbitDB peers', () => {
   // Issue #18
   // ---------------------------------------------------------------------
 
-  test.fail('identity hash is stable across reloads (issue #18)', async () => {
+  test('identity hash is stable across reloads (issue #18)', async () => {
     const first = await openAlice('alice');
     await first.orbitdb.stop();
 
     const second = await openAlice('alice');
     await second.orbitdb.stop();
 
-    // The DID and the keypair are stable; only the document hash moves,
-    // because signIdentity() performs a live WebAuthn assertion whose
-    // result is embedded in the content-addressed document.
+    // signIdentity() reuses the stored proof instead of running a fresh
+    // WebAuthn assertion, so every field — and therefore the content address
+    // of the document — survives the reload.
     expect(second.identity.id).toBe(first.identity.id);
     expect(second.identity.publicKey).toBe(first.identity.publicKey);
     expect(second.identity.signatures.id).toBe(first.identity.signatures.id);
@@ -148,73 +147,90 @@ test.describe('WebAuthn identity across two OrbitDB peers', () => {
     expect(second.identity.hash).toBe(first.identity.hash);
   });
 
-  test.fail(
-    'entries written before and after a reload both replicate (issue #18)',
-    async () => {
-      const load1 = await openAlice('alice');
-      const db1 = await load1.orbitdb.open('reload-test', { type: 'events' });
-      const address = db1.address;
-      await db1.add('entry-1-before-reload');
-      await db1.close();
-      await load1.orbitdb.stop();
+  test('entries written before and after a reload both replicate (issue #18)', async () => {
+    const load1 = await openAlice('alice');
+    const db1 = await load1.orbitdb.open('reload-test', { type: 'events' });
+    const address = db1.address;
+    await db1.add('entry-1-before-reload');
+    await db1.close();
+    await load1.orbitdb.stop();
 
-      // page reload: same keystore, same passkey, fresh Identities
-      const load2 = await openAlice('alice');
-      const db2 = await load2.orbitdb.open(address, { type: 'events' });
-      await db2.add('entry-2-after-reload');
+    // page reload: same keystore, same passkey, fresh Identities
+    const load2 = await openAlice('alice');
+    const db2 = await load2.orbitdb.open(address, { type: 'events' });
+    await db2.add('entry-2-after-reload');
 
-      expect((await db2.all()).length).toBe(2);
+    expect((await db2.all()).length).toBe(2);
 
-      const b = await openBob();
-      const dbB = await b.orbitdb.open(address, { type: 'events' });
-      const seen = await collectValues(dbB, 2, REPLICATION_TIMEOUT);
+    const b = await openBob();
+    const dbB = await b.orbitdb.open(address, { type: 'events' });
+    const seen = await collectValues(dbB, 2, REPLICATION_TIMEOUT);
 
-      await dbB.close();
-      await b.orbitdb.stop();
-      await db2.close();
-      await load2.orbitdb.stop();
+    await dbB.close();
+    await b.orbitdb.stop();
+    await db2.close();
+    await load2.orbitdb.stop();
 
-      // Today bob receives only whichever entry was signed by the identity
-      // document he happened to verify first.
-      expect(seen.sort()).toEqual([
-        'entry-1-before-reload',
-        'entry-2-after-reload',
-      ]);
+    // Both entries were signed under the same identity document, so nothing
+    // collides in verifiedIdentitiesCache and both survive canAppend.
+    expect(seen.sort()).toEqual([
+      'entry-1-before-reload',
+      'entry-2-after-reload',
+    ]);
+  });
+
+  test('a reload reuses the identity document rather than minting one (issue #18)', async () => {
+    // One load at a time — the keystore holds an exclusive lock.
+    const load1 = await openAlice('alice');
+    const hash1 = load1.identity.hash;
+    await load1.orbitdb.stop();
+
+    const load2 = await openAlice('alice');
+    const hash2 = load2.identity.hash;
+
+    const b = await openBob();
+
+    // One document, so verifiedIdentitiesCache in @orbitdb/core (keyed on the
+    // deterministic signatures.id) cannot be poisoned by a second one.
+    expect(hash2).toBe(hash1);
+
+    const doc = await b.identities.getIdentity(hash1);
+    expect(doc).toBeTruthy();
+    expect(await b.identities.verifyIdentity(doc)).toBe(true);
+
+    await b.orbitdb.stop();
+    await load2.orbitdb.stop();
+  });
+
+  test('two devices sharing a passkey keep distinct, independently valid identities', async () => {
+    // Same passkey, separate OrbitDB keystores — the second-device case.
+    // signatures.id derives from the per-device keystore key, not the passkey,
+    // so these documents differ by design and do not collide in the cache.
+    const deviceA = await openAlice('deviceA');
+    await deviceA.orbitdb.stop();
+
+    const deviceB = await createOrbitForCredential({
+      helia: alice,
+      credential,
+      keystorePath: scratch.sub('deviceB-keys'),
+      directory: scratch.sub('deviceB-orbit'),
+      id: 'deviceB',
+    });
+
+    expect(deviceB.identity.id).toBe(deviceA.identity.id);
+    expect(deviceB.identity.publicKey).not.toBe(deviceA.identity.publicKey);
+    expect(deviceB.identity.signatures.id).not.toBe(
+      deviceA.identity.signatures.id
+    );
+
+    const bob2 = await openBob();
+    for (const hash of [deviceA.identity.hash, deviceB.identity.hash]) {
+      const doc = await bob2.identities.getIdentity(hash);
+      expect(doc).toBeTruthy();
+      expect(await bob2.identities.verifyIdentity(doc)).toBe(true);
     }
-  );
 
-  test.fail(
-    'a second identity document from the same DID still verifies (issue #18)',
-    async () => {
-      // One load at a time — the keystore holds an exclusive lock.
-      const load1 = await openAlice('alice');
-      const hash1 = load1.identity.hash;
-      await load1.orbitdb.stop();
-
-      const load2 = await openAlice('alice');
-      const hash2 = load2.identity.hash;
-
-      const b = await openBob();
-
-      // Both documents are retrievable — resolution is not the problem.
-      const doc1 = await b.identities.getIdentity(hash1);
-      const doc2 = await b.identities.getIdentity(hash2);
-      expect(doc1).toBeTruthy();
-      expect(doc2).toBeTruthy();
-
-      // signatures.id is deterministic, so both documents collide on the key
-      // of verifiedIdentitiesCache in @orbitdb/core identities.js. The first
-      // document verified wins; isEqual() then rejects every later document
-      // because signatures.publicKey differs.
-      expect(doc1.signatures.id).toBe(doc2.signatures.id);
-      expect(doc1.publicKey).toBe(doc2.publicKey);
-      expect(doc1.signatures.publicKey).not.toBe(doc2.signatures.publicKey);
-
-      expect(await b.identities.verifyIdentity(doc1)).toBe(true);
-      expect(await b.identities.verifyIdentity(doc2)).toBe(true);
-
-      await b.orbitdb.stop();
-      await load2.orbitdb.stop();
-    }
-  );
+    await bob2.orbitdb.stop();
+    await deviceB.orbitdb.stop();
+  });
 });


### PR DESCRIPTION
Option 2 from #18 — create the document once — which the measurements in that thread show is enough to close the bug on its own.

**Targets `test/two-peer-replication` (#20)**, since it flips the `test.fail()` cases that branch introduced. Merge #20 first, then this retargets to `main` cleanly.

## The change

`signIdentity()` reuses the proof it already produced instead of running a fresh WebAuthn assertion on every page load:

```js
const proofKey = await identityProofKey(this.credential.credentialId, data);
const stored = loadIdentityProof(proofKey);
if (stored) return stored;

const proof = await this.webauthnProvider.sign(data);
storeIdentityProof(proofKey, proof);
return proof;
```

The proof attests that this credential signed this exact payload. That statement does not change between loads, so caching it under the payload it covers is not a shortcut — it is the correct semantics for a value embedded in a content-addressed document. The assertion still happens once, when the identity is first established.

Keyed on `SHA-256(credentialId ‖ 0x1f ‖ payload)`, so a different passkey on the same origin cannot pick up another credential's proof. Storage is `localStorage` with an in-memory fallback, so Node and SSR degrade to process-lifetime reuse rather than breaking.

## Also: the timestamp and the 24-hour expiry

`sign()` put `timestamp: Date.now()` in the envelope, and `verify()` rejected proofs older than 24 hours. Both are removed.

The timestamp alone guaranteed a different document hash on every call, independent of the assertion — pure self-inflicted non-determinism.

The expiry is worse, and it is a latent bug in its own right: the proof sits inside an identity document that every entry ever signed under it references. A proof that expires means the identity behind that history stops verifying after a day. The proof attests authorship, which does not expire.

Compatible in both directions: proofs that still carry a timestamp verify fine (the field is ignored), and 0.3.1 verifying a new proof without one computes `Date.now() - undefined` → `NaN`, and `NaN > maxAge` is false, so it passes.

## Tests

The three `test.fail()` cases from #20 now pass and are flipped:

- identity hash is stable across reloads
- entries written before and after a reload both replicate
- ~~a second identity document from the same DID still verifies~~

The third asserted the broken mechanism itself (`signatures.publicKey` must differ between two documents). With one document per keystore that premise is gone, so it is rewritten around the invariant that now holds — a reload reuses the document, and the remote peer verifies it.

Added in its place: **two devices sharing a passkey keep distinct, independently valid identities.** `signatures.id` derives from the per-device keystore key rather than from the passkey, so a second device legitimately produces a different document — different cache key, no collision, both verify. That is the case Option 2 does not unify and does not need to, and it is worth pinning so a future Option 1 does not quietly change it.

```
two-peer                                                      7 passed
webauthn-focused, unit, verification, integration, standalone 39 passed
lint + format                                                 clean
```

## What this does not do

This is Option 2, not Option 1. The document is stable per device, not *reproducible*: a device that loses its OrbitDB keystore while keeping the passkey still mints a new one, and each device keeps its own. Deriving the signing key from the PRF output would collapse that to a single document per DID everywhere, forever — one block to keep retrievable instead of one per device.

Option 2 is the smaller change and closes the reported failure. Option 1 remains the better end state and this does not block it; the new two-device test documents the behaviour it would change.

Worth noting for that discussion: the WebAuthn assertion only ever happens at identity creation. Entry signing goes through `Identities.sign()` and the keystore key, never the authenticator — so making the document deterministic costs no per-write user verification, because there is none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
