### PR TITLE
ci: make the publish auth failure legible, and stop the audit annotating errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,19 +176,33 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Reported, not enforced. The dev tree pulls helia and libp2p, which drag
-      # in ~86 advisories that this package cannot act on. Kept visible so
-      # regressions are noticeable without blocking every release.
-      - name: Audit (full tree, informational)
-        continue-on-error: true
-        run: pnpm audit --audit-level=moderate
-
-      # What consumers actually install. Currently 5 advisories, all via
-      # iso-web > iso-kv > conf > ajv, so the enforced floor is `critical`
-      # until that chain is bumped. Tighten to high, then moderate, as it clears.
-      - name: Audit production dependencies (informational)
-        continue-on-error: true
-        run: pnpm audit --prod --audit-level=moderate
+      # Informational, and deliberately not `continue-on-error`. That keeps the
+      # job green but still records a red "Process completed with exit code 1"
+      # annotation on the run, which reads like a failure the job is hiding.
+      # Swallowing the status instead means the counts land in the summary and
+      # nothing is annotated as an error.
+      #
+      # Why informational: the dev tree pulls helia and libp2p, worth ~86
+      # advisories this package cannot act on. Even --prod reports 5, all via
+      # iso-web > iso-kv > conf > ajv. The enforced floor below is therefore
+      # `critical`; tighten it to high, then moderate, as that chain clears.
+      - name: Audit (report)
+        run: |
+          {
+            echo "### Dependency audit"
+            echo
+            for scope in "full tree:" "production only:--prod"; do
+              label="${scope%%:*}"; flag="${scope#*:}"
+              echo "<details><summary>$label</summary>"
+              echo
+              echo '```'
+              pnpm audit $flag --audit-level=moderate 2>&1 | tail -5 || true
+              echo '```'
+              echo
+              echo "</details>"
+              echo
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Audit production dependencies (enforced at critical)
         run: pnpm audit --prod --audit-level=critical

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,35 @@ jobs:
       - name: Use an npm that supports trusted publishing
         run: npm install -g npm@latest
 
+      # npm falls back to token auth and fails with a bare ENEEDAUTH when the
+      # OIDC exchange does not succeed, which says nothing about why. Ask the
+      # registry directly first so a misconfigured trusted publisher is legible.
+      - name: Check the trusted-publishing exchange
+        if: inputs.auth != 'token'
+        run: |
+          token=$(curl -sf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).value")
+
+          echo "OIDC claims npm will match against:"
+          node -e "
+            const c = JSON.parse(Buffer.from('$token'.split('.')[1], 'base64url'));
+            console.log('  repository:   ' + c.repository);
+            console.log('  workflow_ref: ' + c.workflow_ref);
+            console.log('  environment:  ' + (c.environment ?? '(none)'));
+          "
+
+          code=$(curl -s -o /tmp/exchange.json -w '%{http_code}' -X POST \
+            -H 'Content-Type: application/json' \
+            -d "{\"id_token\":\"$token\"}" \
+            https://registry.npmjs.org/-/npm/v1/oidc/token/exchange)
+          echo "exchange endpoint HTTP $code"
+          if [ "$code" != "200" ]; then
+            echo "::error::npm rejected the OIDC token — the trusted publisher for this package does not match the claims above."
+            sed -e 's/"token":"[^"]*"/"token":"REDACTED"/' /tmp/exchange.json
+            exit 1
+          fi
+          echo "trusted publishing is configured correctly"
+
       # --ignore-scripts: prepublishOnly would re-run the gate the `test` job
       # just cleared.
       - name: Publish


### PR DESCRIPTION
Two things from the v0.4.0 tag run. **Nothing was published** — the run failed at `publish`, so `0.4.0` is still free.

## The audit annotations you spotted

Green job, two red annotations — you were right that it looked wrong.

The two informational audit steps used `continue-on-error: true`. That keeps the *job* green, but GitHub still records the step's non-zero exit as an error annotation on the run. So the summary showed `Security Audit ✅` next to `Security Audit ✗ Process completed with exit code 1`, twice, which reads like a failure being papered over.

They are now a single step that writes the counts into the job summary and swallows the exit status, so nothing is annotated. The enforced gate — `pnpm audit --prod --audit-level=critical` — is unchanged and still genuinely fails the job if it trips.

For the record, the numbers behind it: full tree 86 advisories (1 critical, 46 high), all from the helia/libp2p dev tree; `--prod` 5 (4× `fast-uri` high, 1× `ajv` moderate) via `iso-web > iso-kv > conf > ajv`.

## Why the publish failed

```
authenticating with trusted publishing (OIDC)
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

I measured the two obvious suspects on a runner before changing anything, and both are fine:

- **OIDC works.** `ACTIONS_ID_TOKEN_REQUEST_URL` is set, the token endpoint returns HTTP 200, and the claims are correct. `id-token: write` is granted — the "GITHUB_TOKEN Permissions" log group just doesn't list `Id Token`, which I initially misread as it being absent.
- **npm is new enough.** Bundled 10.9.8, upgraded to 12.0.2.

What remains is the exchange of the OIDC token for a registry token. When that is rejected, npm says nothing about it — it quietly falls back to token auth and reports that it isn't logged in. Which, with an invalid `NPM_TOKEN` in the repo, is a dead end to debug from.

So the publish job now does that exchange itself first, prints the claims npm matches a trusted publisher against:

```
  repository:   Le-Space/orbitdb-identity-provider-webauthn-did
  workflow_ref: Le-Space/...:.github/workflows/release.yml@refs/tags/v0.4.0
  environment:  (none)
```

and fails with the registry's own response if it is rejected. A trusted publisher configured for a different workflow filename, or one that expects a deployment environment, becomes readable instead of masquerading as a missing token.

## Next

After merging I will move the `v0.4.0` tag onto the new tip and re-run. Re-tagging is safe — nothing was published, so the version is untouched.

If the exchange step then reports a mismatch, the fix is on the npmjs.com side and the message will say exactly which claim disagrees. Worth double-checking there that the publisher is registered against workflow **`release.yml`** and with **no environment**, since those are the two fields that usually differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
