### PR TITLE
ci: fall back to NPM_TOKEN when trusted publishing is unavailable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,13 +145,33 @@ jobs:
       # shows whether it attempts the OIDC exchange at all.
       - name: Publish
         run: |
+          publish() { npm publish --access public --provenance --ignore-scripts "$@"; }
+
           if [ "${{ inputs.auth }}" = "token" ]; then
-            echo "authenticating with NPM_TOKEN"
+            echo "authenticating with NPM_TOKEN (explicitly requested)"
             npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
-          else
-            echo "authenticating with trusted publishing (OIDC)"
+            publish
+            exit $?
           fi
-          npm publish --access public --provenance --ignore-scripts --loglevel=verbose
+
+          # A tag push cannot pass inputs, so it lands here. Try trusted
+          # publishing first — it needs no long-lived secret — and fall back to
+          # NPM_TOKEN if the registry has no trusted publisher for this package.
+          # npm publish is atomic, so a failed attempt has published nothing and
+          # retrying is safe.
+          echo "attempting trusted publishing (OIDC)"
+          if publish --loglevel=verbose; then
+            exit 0
+          fi
+
+          if [ -z "$NPM_TOKEN" ]; then
+            echo "::error::Trusted publishing failed and no NPM_TOKEN is configured."
+            exit 1
+          fi
+
+          echo "::warning::Trusted publishing did not succeed; falling back to NPM_TOKEN. See the verbose log above for why."
+          npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+          publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Answers the question directly: adding the `NPM_TOKEN` secret on its own changed nothing for `git tag && git push`. A tag push cannot pass workflow inputs, so it always took the OIDC path — the token was only ever reachable through a manual run with `auth: token`.

**The new token is valid**: `npm whoami` returns `nandiji` in the check run. The previous one returned E401.

## What changes

The publish step now tries trusted publishing first and falls back to `NPM_TOKEN` when the registry has no trusted publisher for the package — which is the current state:

```
npm http fetch POST 404 .../oidc/token/exchange/package/@le-space%2forbitdb-identity-provider-webauthn-did
npm verbose oidc Failed token exchange request with body message:
                 OIDC token exchange error - package not found
```

OIDC stays first on purpose: it needs no long-lived secret, and once the trusted publisher is registered against the package the fallback simply stops being reached — no further workflow change needed. `npm publish` is atomic, so the failed first attempt published nothing and the retry is safe.

An explicit `auth: token` run still goes straight to the token.

## After merging

I will move the `v0.4.0` tag onto the new tip so the tag runs this version of the workflow, and 0.4.0 should land on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)