### PR TITLE
feat: derive the OrbitDB signing key from the passkey PRF output (0.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## Unreleased
 
+## 0.4.1
+
+### Added
+
+- Derive the OrbitDB signing key from the passkey PRF output instead of letting
+  the keystore generate a random one. `Identities.createIdentity` takes
+  `keystore.getKey(id) || keystore.createKey(id)`, and `createKey` is random, so
+  the same passkey previously produced a different `publicKey` and
+  `signatures.id` — and therefore a different identity document — on every
+  device. Seeding the keystore during `getId()`, the last point before OrbitDB
+  asks for the key, makes the whole document reproducible: one block to keep
+  retrievable for a DID instead of one per device, and a device that loses its
+  keystore while keeping the passkey reconstructs the same identity rather than
+  minting another. Needs no change to `@orbitdb/core`.
+- `createCredential()` now requests the PRF extension even when the keystore is
+  not encrypted, and stores the input. Without a stored input the output would
+  differ per call, so a credential registered without one can never get a
+  reproducible identity. Requesting it is harmless where unsupported.
+
+### Notes
+
+- Falls back cleanly. No PRF support, no stored input, or a refused assertion
+  leaves the keystore to generate its own key — 0.4.0 behaviour, stable per
+  device but not across devices. Opt out with
+  `deriveSigningKeyFromPrf: false`.
+- An existing keystore key is never replaced. Swapping it under a device that
+  already has history would mint a second document for the DID, which is what
+  this avoids. Installs upgrading from 0.4.0 keep their key; fresh installs get
+  a reproducible identity.
+- Costs one extra assertion the first time an identity is created on a device.
+  The key is persisted, so later loads do not repeat it.
+
 ## 0.4.0
 
 ### Breaking

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@le-space/orbitdb-identity-provider-webauthn-did",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "WebAuthn-based DID identity provider for OrbitDB for hardware-secured wallets and biometric Passkey authentication",
   "main": "src/index.js",
   "types": "types/index.d.ts",

--- a/src/keystore/derived-signing-key.js
+++ b/src/keystore/derived-signing-key.js
@@ -1,0 +1,198 @@
+/**
+ * @module DerivedSigningKey
+ * @description
+ * Derives the OrbitDB signing key deterministically from the passkey's PRF
+ * output instead of letting the keystore generate a random one.
+ *
+ * `Identities.createIdentity` in `@orbitdb/core` does:
+ *
+ *     const privateKey = await keystore.getKey(id) || await keystore.createKey(id)
+ *     const publicKey  = keystore.getPublic(privateKey)
+ *     const idSignature = await signMessage(privateKey, id)
+ *
+ * `createKey` generates a random secp256k1 key, so `publicKey` and
+ * `signatures.id` differ on every device even for the same passkey — one
+ * identity document per device. Seeding the keystore with a PRF-derived key
+ * before OrbitDB asks for it makes all of that reproducible: the same passkey
+ * yields the same document everywhere, so there is exactly one block to keep
+ * retrievable and a device that loses its keystore reconstructs the identity
+ * rather than minting another one.
+ *
+ * Needs no change to `@orbitdb/core` — it only has to happen before
+ * `getKey(id)` is called, which `getId()` is.
+ *
+ * See issue #18, option 1.
+ */
+import { logger } from '@libp2p/logger';
+import { privateKeyFromRaw } from '@libp2p/crypto/keys';
+
+import { CRYPTO_ALGORITHMS } from '../constants.js';
+import { buildCredentialRequestOptions } from '../webauthn/config.js';
+
+const log = logger('orbitdb-identity-provider-webauthn-did:derived-key');
+
+// Bumping this rotates every derived key, so treat it as a breaking change.
+const DERIVATION_INFO = 'orbitdb-identity-provider-webauthn-did:signing-key:v1';
+
+const SECP256K1_KEY_BYTES = 32;
+
+/**
+ * HKDF-SHA256 a 32-byte candidate from the PRF seed.
+ * @param {Uint8Array} seed - PRF output.
+ * @param {string} info - Domain separation string.
+ * @returns {Promise<Uint8Array>} 32 bytes.
+ */
+async function hkdf(seed, info) {
+  const baseKey = await crypto.subtle.importKey(
+    'raw',
+    seed,
+    CRYPTO_ALGORITHMS.HKDF,
+    false,
+    ['deriveBits']
+  );
+  const bits = await crypto.subtle.deriveBits(
+    {
+      name: CRYPTO_ALGORITHMS.HKDF,
+      hash: CRYPTO_ALGORITHMS.SHA_256,
+      salt: new Uint8Array(0),
+      info: new TextEncoder().encode(info),
+    },
+    baseKey,
+    SECP256K1_KEY_BYTES * 8
+  );
+  return new Uint8Array(bits);
+}
+
+/**
+ * Turn a PRF seed into a valid secp256k1 private key.
+ *
+ * Values outside the curve order are invalid. That is vanishingly unlikely for
+ * a 256-bit hash, but retrying with a counter keeps the derivation total and
+ * deterministic rather than probabilistic.
+ *
+ * @param {Uint8Array} seed - PRF output.
+ * @param {string} did - Identity DID, mixed in for domain separation.
+ * @returns {Promise<Uint8Array>} A valid 32-byte secp256k1 private key.
+ */
+export async function deriveSigningKeyBytes(seed, did) {
+  for (let counter = 0; counter < 256; counter++) {
+    const candidate = await hkdf(seed, `${DERIVATION_INFO}:${did}:${counter}`);
+    try {
+      privateKeyFromRaw(candidate);
+      return candidate;
+    } catch {
+      log('derived scalar %d was not a valid secp256k1 key, retrying', counter);
+    }
+  }
+  // Unreachable short of a broken hash.
+  throw new Error('could not derive a valid secp256k1 key from the PRF seed');
+}
+
+/**
+ * Ask the authenticator for the credential's PRF output.
+ *
+ * Returns null whenever a stable PRF output cannot be obtained — no stored
+ * PRF input, no PRF support, or a refused assertion. Callers must treat null
+ * as "carry on without a derived key" rather than as an error.
+ *
+ * @param {Object} credential - Stored WebAuthn credential info.
+ * @param {Object} [options]
+ * @param {string} [options.rpId] - Relying party id.
+ * @returns {Promise<Uint8Array|null>} PRF output, or null.
+ */
+export async function getPrfOutput(credential, { rpId } = {}) {
+  // Without the original input the output would differ per call, which is
+  // worse than not deriving at all.
+  if (!credential?.prfInput) {
+    log('credential has no stored prfInput; cannot derive a stable key');
+    return null;
+  }
+
+  if (typeof navigator === 'undefined' || !navigator.credentials?.get) {
+    log('no WebAuthn available; cannot derive a key');
+    return null;
+  }
+
+  const rawCredentialId =
+    credential.rawCredentialId instanceof Uint8Array
+      ? credential.rawCredentialId
+      : new Uint8Array(credential.rawCredentialId ?? []);
+
+  try {
+    const assertion = await navigator.credentials.get(
+      buildCredentialRequestOptions({
+        challenge: await crypto.subtle.digest(
+          CRYPTO_ALGORITHMS.SHA_256,
+          new TextEncoder().encode(DERIVATION_INFO)
+        ),
+        credentialId: rawCredentialId,
+        rpId: rpId ?? globalThis.window?.location?.hostname,
+        userVerification: 'required',
+        extensions: { prf: { eval: { first: credential.prfInput } } },
+      })
+    );
+
+    const results = assertion?.getClientExtensionResults?.()?.prf?.results;
+    if (!results?.first) {
+      log('authenticator returned no PRF output');
+      return null;
+    }
+    return new Uint8Array(results.first);
+  } catch (error) {
+    log('PRF assertion failed: %s', error.message);
+    return null;
+  }
+}
+
+/**
+ * Seed the keystore with a PRF-derived signing key for this DID.
+ *
+ * An existing key is never replaced. Overwriting one would change `publicKey`
+ * and `signatures.id`, producing a second identity document for the same DID —
+ * precisely what this is meant to avoid. Installs that already hold a random
+ * key therefore keep it and stay on 0.4.0 behaviour, which is stable per
+ * device; only fresh installs get a reproducible identity.
+ *
+ * @param {Object} params
+ * @param {Object} params.keystore - OrbitDB keystore.
+ * @param {string} params.did - Identity DID.
+ * @param {Object} params.credential - Stored WebAuthn credential info.
+ * @param {string} [params.rpId] - Relying party id.
+ * @returns {Promise<'derived'|'existing'|'unavailable'>} What happened.
+ */
+export async function ensureDerivedSigningKey({
+  keystore,
+  did,
+  credential,
+  rpId,
+}) {
+  if (!keystore || !did || !credential) return 'unavailable';
+
+  try {
+    if (await keystore.getKey(did)) {
+      log('keystore already holds a key for this DID; leaving it alone');
+      return 'existing';
+    }
+  } catch (error) {
+    log('could not read the keystore: %s', error.message);
+    return 'unavailable';
+  }
+
+  const seed = await getPrfOutput(credential, { rpId });
+  if (!seed) {
+    log(
+      'no PRF output; falling back to a keystore-generated key, so this identity is stable per device but not reproducible across devices'
+    );
+    return 'unavailable';
+  }
+
+  try {
+    const privateKey = await deriveSigningKeyBytes(seed, did);
+    await keystore.addKey(did, { privateKey });
+    log('seeded the keystore with a PRF-derived signing key');
+    return 'derived';
+  } catch (error) {
+    log('failed to seed the derived key: %s', error.message);
+    return 'unavailable';
+  }
+}

--- a/src/keystore/provider.js
+++ b/src/keystore/provider.js
@@ -7,6 +7,7 @@ import { generateKeyPair } from '@libp2p/crypto/keys';
 import { varint } from 'multiformats';
 import { base58btc } from 'multiformats/bases/base58';
 import * as KeystoreEncryption from './encryption.js';
+import { ensureDerivedSigningKey } from './derived-signing-key.js';
 import { WebAuthnDIDProvider } from '../webauthn/provider.js';
 import {
   identityProofKey,
@@ -56,8 +57,12 @@ export class OrbitDBWebAuthnIdentityProvider {
     keystoreKeyType = KEY_TYPES.SECP256K1,
     encryptKeystore = false,
     keystoreEncryptionMethod = KEYSTORE_ENCRYPTION_METHODS.PRF,
+    deriveSigningKeyFromPrf = true,
   }) {
     this.credential = webauthnCredential;
+    // Costs one extra assertion the first time an identity is created on a
+    // device. Set false to keep a keystore-generated key instead.
+    this.deriveSigningKeyFromPrf = deriveSigningKeyFromPrf;
     this.webauthnProvider = new WebAuthnDIDProvider(webauthnCredential);
     this.type = IDENTITY_TYPES.WEBAUTHN; // Set instance property
     this.useKeystoreDID = useKeystoreDID; // Flag to use Ed25519 DID from keystore
@@ -76,7 +81,17 @@ export class OrbitDBWebAuthnIdentityProvider {
    * Resolve the identity DID.
    * @returns {Promise<string>} DID string.
    */
-  async getId() {
+  /**
+   * Resolve the identity DID.
+   *
+   * OrbitDB passes its own keystore in `options` and calls this before
+   * `keystore.getKey(id)`, which is the only window in which the signing key
+   * can be seeded deterministically. See derived-signing-key.js.
+   *
+   * @param {Object} [options] - Options supplied by OrbitDB.
+   * @returns {Promise<string>} DID string.
+   */
+  async getId(options = {}) {
     identityLog('getId() called');
 
     // If useKeystoreDID flag is set, create Ed25519 DID from keystore
@@ -95,6 +110,22 @@ export class OrbitDBWebAuthnIdentityProvider {
 
     // Default: Return P-256 DID from WebAuthn credential
     const did = await WebAuthnDIDProvider.createDID(this.credential);
+
+    // Seed the signing key before OrbitDB reaches for it. Never fatal: without
+    // PRF the keystore generates its own key and the identity stays stable per
+    // device, just not reproducible across them.
+    if (this.deriveSigningKeyFromPrf !== false) {
+      const keystore = options.keystore ?? this.keystore;
+      if (keystore) {
+        const outcome = await ensureDerivedSigningKey({
+          keystore,
+          did,
+          credential: this.credential,
+        });
+        identityLog('Derived signing key: %s', outcome);
+      }
+    }
+
     identityLog(
       'getId() returning P-256 DID: %s',
       did.substring(0, 32) + '...'

--- a/src/webauthn/provider.js
+++ b/src/webauthn/provider.js
@@ -199,6 +199,19 @@ export class WebAuthnDIDProvider {
       // Note: largeBlob write happens after credential creation
     }
 
+    // Request PRF even when the keystore is not encrypted. The stored input is
+    // what lets the OrbitDB signing key be derived reproducibly later, so a
+    // credential registered without it can never get a reproducible identity.
+    // Requesting the extension is harmless where it is unsupported: the
+    // authenticator simply returns no PRF results.
+    if (!prfInput) {
+      const prfConfig = KeystoreEncryption.addPRFToCredentialOptions(
+        credentialOptions.publicKey
+      );
+      credentialOptions.publicKey = prfConfig.credentialOptions;
+      prfInput = prfConfig.prfInput;
+    }
+
     try {
       const credential = await navigator.credentials.create(credentialOptions);
 

--- a/tests/helpers/mock-authenticator.js
+++ b/tests/helpers/mock-authenticator.js
@@ -54,6 +54,13 @@ export async function createMockAuthenticator({
   rpId = 'localhost',
   exposeGetPublicKey = true,
   credentialIdLength = 32,
+  // Real authenticators derive PRF from a per-credential secret, so the output
+  // is stable for a given input and identical on any device holding the same
+  // synced passkey. `prfSecret` models exactly that: pass the same value to two
+  // authenticators to represent one passkey on two devices. Set supportsPrf
+  // false to model an authenticator without the extension.
+  supportsPrf = true,
+  prfSecret = null,
 } = {}) {
   const keypair = await crypto.subtle.generateKey(
     { name: 'ECDSA', namedCurve: 'P-256' },
@@ -73,7 +80,20 @@ export async function createMockAuthenticator({
   );
   const rpIdHash = await sha256(new TextEncoder().encode(rpId));
 
-  const state = { signCount: 0, assertions: 0, creations: 0 };
+  const state = { signCount: 0, assertions: 0, creations: 0, prfEvals: 0 };
+
+  // Per-credential secret the PRF output is derived from.
+  const prfKey = prfSecret ?? crypto.getRandomValues(new Uint8Array(32));
+
+  const evaluatePrf = async (input) => {
+    state.prfEvals += 1;
+    const material = concatBytes([
+      prfKey,
+      new TextEncoder().encode('prf'),
+      new Uint8Array(input),
+    ]);
+    return sha256(material);
+  };
 
   const coseKey = new Uint8Array(
     encode(
@@ -182,6 +202,16 @@ export async function createMockAuthenticator({
         const clientDataJSON = buildClientDataJSON('webauthn.get', challenge);
         const clientDataHash = await sha256(clientDataJSON);
 
+        // PRF: deterministic in the input, so the same passkey always yields
+        // the same output. Absent entirely when the authenticator has no PRF.
+        const prfEval = options?.publicKey?.extensions?.prf?.eval;
+        const extensionResults = {};
+        if (supportsPrf && prfEval?.first) {
+          extensionResults.prf = {
+            results: { first: (await evaluatePrf(prfEval.first)).buffer },
+          };
+        }
+
         // ECDSA signatures are randomised: identical input, different output
         const signature = new Uint8Array(
           await crypto.subtle.sign(
@@ -207,7 +237,7 @@ export async function createMockAuthenticator({
             signature: signature.buffer,
             userHandle: null,
           },
-          getClientExtensionResults: () => ({}),
+          getClientExtensionResults: () => extensionResults,
         };
       },
     },

--- a/tests/webauthn-two-peer-replication.test.js
+++ b/tests/webauthn-two-peer-replication.test.js
@@ -202,10 +202,10 @@ test.describe('WebAuthn identity across two OrbitDB peers', () => {
     await load2.orbitdb.stop();
   });
 
-  test('two devices sharing a passkey keep distinct, independently valid identities', async () => {
-    // Same passkey, separate OrbitDB keystores — the second-device case.
-    // signatures.id derives from the per-device keystore key, not the passkey,
-    // so these documents differ by design and do not collide in the cache.
+  test('two devices sharing a passkey derive the same identity document', async () => {
+    // The point of deriving the signing key from PRF: separate keystores, one
+    // passkey, and the identity document comes out identical — so there is a
+    // single block to keep retrievable rather than one per device.
     const deviceA = await openAlice('deviceA');
     await deviceA.orbitdb.stop();
 
@@ -218,10 +218,9 @@ test.describe('WebAuthn identity across two OrbitDB peers', () => {
     });
 
     expect(deviceB.identity.id).toBe(deviceA.identity.id);
-    expect(deviceB.identity.publicKey).not.toBe(deviceA.identity.publicKey);
-    expect(deviceB.identity.signatures.id).not.toBe(
-      deviceA.identity.signatures.id
-    );
+    expect(deviceB.identity.publicKey).toBe(deviceA.identity.publicKey);
+    expect(deviceB.identity.signatures.id).toBe(deviceA.identity.signatures.id);
+    expect(deviceB.identity.hash).toBe(deviceA.identity.hash);
 
     const bob2 = await openBob();
     for (const hash of [deviceA.identity.hash, deviceB.identity.hash]) {
@@ -232,5 +231,77 @@ test.describe('WebAuthn identity across two OrbitDB peers', () => {
 
     await bob2.orbitdb.stop();
     await deviceB.orbitdb.stop();
+  });
+
+  test('an authenticator without PRF still works, one identity per device', async () => {
+    // The fallback. No PRF output means no reproducible key, so the keystore
+    // generates its own — 0.4.0 behaviour: stable per device, distinct across
+    // devices, and every document still valid.
+    restoreAuthenticator?.();
+    const noPrf = await createMockAuthenticator({ supportsPrf: false });
+    restoreAuthenticator = installMockAuthenticator(noPrf);
+
+    const { WebAuthnDIDProvider } = await import('../src/webauthn/provider.js');
+    const plainCredential = await WebAuthnDIDProvider.createCredential({
+      userId: 'no-prf-user',
+      displayName: 'No PRF User',
+    });
+
+    const open = (name) =>
+      createOrbitForCredential({
+        helia: alice,
+        credential: plainCredential,
+        keystorePath: scratch.sub(`${name}-keys`),
+        directory: scratch.sub(`${name}-orbit`),
+        id: name,
+      });
+
+    const first = await open('noPrfA');
+    const firstHash = first.identity.hash;
+    await first.orbitdb.stop();
+
+    // Reloading the same device is still stable — that is 0.4.0's fix.
+    const reloaded = await open('noPrfA');
+    expect(reloaded.identity.hash).toBe(firstHash);
+    await reloaded.orbitdb.stop();
+
+    // A second device diverges, which is the cost of having no PRF.
+    const second = await open('noPrfB');
+    expect(second.identity.id).toBe(first.identity.id);
+    expect(second.identity.publicKey).not.toBe(first.identity.publicKey);
+
+    const b = await openBob();
+    for (const hash of [firstHash, second.identity.hash]) {
+      const doc = await b.identities.getIdentity(hash);
+      expect(doc).toBeTruthy();
+      expect(await b.identities.verifyIdentity(doc)).toBe(true);
+    }
+
+    await b.orbitdb.stop();
+    await second.orbitdb.stop();
+  });
+
+  test('an existing keystore key is never replaced', async () => {
+    // Upgrading from 0.4.0 must not swap the signing key underneath a device
+    // that already has history: that would mint a second document for the DID.
+    const { KeyStore } = await import('@orbitdb/core');
+    const { ensureDerivedSigningKey } =
+      await import('../src/keystore/derived-signing-key.js');
+    const { WebAuthnDIDProvider } = await import('../src/webauthn/provider.js');
+
+    const did = await WebAuthnDIDProvider.createDID(credential);
+    const keystore = await KeyStore({ path: scratch.sub('preexisting-keys') });
+    await keystore.createKey(did); // whatever 0.4.0 left behind
+    const before = keystore.getPublic(await keystore.getKey(did));
+
+    const outcome = await ensureDerivedSigningKey({
+      keystore,
+      did,
+      credential,
+    });
+
+    expect(outcome).toBe('existing');
+    expect(keystore.getPublic(await keystore.getKey(did))).toBe(before);
+    await keystore.close();
   });
 });


### PR DESCRIPTION
Option 1 from #18. 0.4.0 made the identity document stable *per device*; this makes it reproducible *across* devices.

## The remaining gap after 0.4.0

`Identities.createIdentity` in `@orbitdb/core`:

```js
const privateKey = await keystore.getKey(id) || await keystore.createKey(id)
const publicKey  = keystore.getPublic(privateKey)
const idSignature = await signMessage(privateKey, id)
```

`createKey` generates a **random** secp256k1 key. So the same passkey still produced a different `publicKey` and `signatures.id` — and therefore a different identity document — on every device. Measured before this change:

```
two devices, same passkey, different keystores
  same DID?            true
  same publicKey?      false
  same signatures.id?  false
```

That is not a correctness bug — the documents do not collide in `verifiedIdentitiesCache` and both validate — but it means one identity block per device has to stay retrievable forever, and a device that loses its keystore mints another one.

## The fix

Seed the keystore during `getId()` — the last point before OrbitDB reaches for the key — with a key derived from the passkey's PRF output. **No change to `@orbitdb/core` needed.**

Derivation is HKDF-SHA256 over the PRF output, domain-separated by version and DID, retried with a counter until the result is a valid secp256k1 scalar so it is total rather than probabilistic. `crypto.subtle` only, no new dependency.

`createCredential()` now also requests PRF when the keystore is *not* encrypted, and stores the input. Without a stored input the output would differ per call, so a credential registered without one could never get a reproducible identity. Requesting the extension where it is unsupported is harmless — the authenticator just returns no results.

## The fallback you asked for

Three ways to end up without a derived key, all handled the same way — the keystore generates its own, which is exactly 0.4.0 behaviour:

- the authenticator has no PRF extension
- the credential has no stored PRF input (registered before this version)
- the assertion is refused or fails

`ensureDerivedSigningKey()` returns `'derived' | 'existing' | 'unavailable'` and never throws. Opt out entirely with `deriveSigningKeyFromPrf: false`.

**An existing keystore key is never replaced.** Swapping it under a device that already has history would mint a second document for the DID — the very thing being avoided. Installs upgrading from 0.4.0 keep their key; only fresh installs get a reproducible identity.

Cost: one extra assertion the first time an identity is created on a device. The key is persisted, so later loads do not repeat it.

## Tests

The mock authenticator gained a PRF implementation — deterministic in its input, derived from a per-credential secret that can be shared between two authenticators to model one passkey on two devices, and omittable to model an authenticator without the extension.

```
two-peer                        9 passed
```

Three of those are new or inverted:

- `two devices sharing a passkey derive the same identity document` — was previously asserting the opposite, which is precisely the behaviour this changes
- `an authenticator without PRF still works, one identity per device` — the fallback, including that a reload is still stable
- `an existing keystore key is never replaced`

No regressions: node suites 34 passed, browser suites 28 passed, encrypted-keystore suites 27 passed.

## Versioning

`0.4.1`. No API change, the DID is unchanged, and entries written under a previous document stay valid — the documents differ but do not collide, so nothing breaks for an existing install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
