### PR TITLE
fix: stop writing WebAuthn credentials to the console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,27 @@
   removed `missingRefs` option.
   `pnpm audit --prod` now reports nothing, so the enforced CI gate moves from
   `critical` to `moderate`.
+- Stop writing WebAuthn credentials to the console. `logWebAuthnResponse()` dumped
+  the whole credential — `rawId`, `attestationObject`, `clientDataJSON`,
+  `signature`, `getPublicKey()` and `getClientExtensionResults()` — on every
+  `navigator.credentials.create()` and `.get()`, unconditionally and in
+  production code paths. Two things made that more than noise: extension results
+  can carry the PRF output, which is what both the keystore encryption and (since
+  0.4.1) the OrbitDB signing key derive from, and `rawId` is a stable per-user,
+  per-RP identifier that landed in any console capture or session replay the
+  embedding app happened to run. Replaced by a single shared helper that logs
+  shape only — byte lengths, presence flags and the names of the extensions that
+  returned results — behind the package debug logger, so it is silent unless
+  `DEBUG=orbitdb-identity-provider-webauthn-did*` is set. Closes #22.
+
+### Changed
+
+- Route the remaining informational `console.log` output through the debug
+  logger. A library should not print unconditionally; `console.error` and
+  `console.warn` stay as they are, so genuine failures remain visible. `src/`
+  went from 61 `console.*` calls to 16, none of them `console.log`.
+- Deduplicate three byte-identical copies of the WebAuthn debug helper into
+  `src/webauthn/debug-log.js`.
 
 ## 0.4.1
 

--- a/playwright.node.config.js
+++ b/playwright.node.config.js
@@ -17,6 +17,7 @@ export default defineConfig({
   testDir: './tests',
   testMatch: [
     'standalone-toolkit.test.js',
+    'webauthn-debug-log.test.js',
     'webauthn-attestation-parsing.test.js',
     'webauthn-two-peer-replication.test.js',
   ],

--- a/src/keystore/provider.js
+++ b/src/keystore/provider.js
@@ -79,10 +79,6 @@ export class OrbitDBWebAuthnIdentityProvider {
 
   /**
    * Resolve the identity DID.
-   * @returns {Promise<string>} DID string.
-   */
-  /**
-   * Resolve the identity DID.
    *
    * OrbitDB passes its own keystore in `options` and calls this before
    * `keystore.getKey(id)`, which is the only window in which the signing key
@@ -352,11 +348,11 @@ export class OrbitDBWebAuthnIdentityProvider {
    */
   async createEncryptedKeystore() {
     if (!this.encryptKeystore) {
-      console.log('ℹ️ Keystore encryption not enabled, skipping');
+      identityLog('ℹ️ Keystore encryption not enabled, skipping');
       return;
     }
 
-    console.log(
+    identityLog(
       '🔐 Creating encrypted keystore with method:',
       this.keystoreEncryptionMethod
     );
@@ -448,7 +444,7 @@ export class OrbitDBWebAuthnIdentityProvider {
       }
 
       // Store encrypted keystore
-      console.log(
+      identityLog(
         '💾 Storing encrypted keystore with credentialId:',
         this.credential.credentialId?.substring(0, 16) + '...'
       );
@@ -461,7 +457,7 @@ export class OrbitDBWebAuthnIdentityProvider {
         publicKey: publicKeyBytes,
         keyType,
       };
-      console.log('✅ Encrypted keystore stored successfully');
+      identityLog('✅ Encrypted keystore stored successfully');
 
       identityLog('Encrypted keystore created and stored successfully');
     } catch (error) {
@@ -649,15 +645,15 @@ export class OrbitDBWebAuthnIdentityProvider {
     // If encryption is enabled, create and unlock encrypted keystore
     if (encryptKeystore && keystore) {
       try {
-        console.log(
+        identityLog(
           '🔐 Creating encrypted keystore with',
           keystoreEncryptionMethod,
           '...'
         );
         await provider.createEncryptedKeystore();
-        console.log('🔓 Unlocking encrypted keystore...');
+        identityLog('🔓 Unlocking encrypted keystore...');
         await provider.unlockEncryptedKeystore();
-        console.log('✅ Encrypted keystore created and unlocked successfully');
+        identityLog('✅ Encrypted keystore created and unlocked successfully');
         identityLog('Encrypted keystore created and unlocked');
       } catch (error) {
         // Log error visibly so users know encryption failed

--- a/src/varsig/assertion.js
+++ b/src/varsig/assertion.js
@@ -19,39 +19,10 @@ import {
   VarsigVerificationError,
   WebAuthnAuthenticationError,
 } from '../errors.js';
+import { logWebAuthnResponse } from '../webauthn/debug-log.js';
 
 const isTestMode = () =>
   typeof window !== 'undefined' && window.__PLAYWRIGHT__ === true;
-
-function logWebAuthnResponse(label, credential) {
-  const response = credential?.response;
-  const getPublicKeyResult =
-    typeof response?.getPublicKey === 'function'
-      ? response.getPublicKey()
-      : null;
-
-  console.group(`[WebAuthn Debug] ${label}`);
-  console.log('credential', credential);
-  console.log('credential.id', credential?.id);
-  console.log('credential.type', credential?.type);
-  console.log('credential.rawId', credential?.rawId);
-  console.log('credential.response', response);
-  console.log('response.clientDataJSON', response?.clientDataJSON);
-  console.log('response.attestationObject', response?.attestationObject);
-  console.log('response.authenticatorData', response?.authenticatorData);
-  console.log('response.signature', response?.signature);
-  console.log('response.userHandle', response?.userHandle);
-  console.log(
-    'response.getPublicKey exists',
-    typeof response?.getPublicKey === 'function'
-  );
-  console.log('response.getPublicKey()', getPublicKeyResult);
-  console.log(
-    'client extension results',
-    credential?.getClientExtensionResults?.() || null
-  );
-  console.groupEnd();
-}
 
 /**
  * Run a WebAuthn assertion for a payload.

--- a/src/varsig/credential.js
+++ b/src/varsig/credential.js
@@ -5,39 +5,10 @@ import { DIDKey } from 'iso-did';
 import { parseAttestationObject } from 'iso-passkeys';
 import { toArrayBuffer } from './utils.js';
 import { buildAuthenticatorSelection } from '../webauthn/config.js';
+import { logWebAuthnResponse } from '../webauthn/debug-log.js';
 
 const isTestMode = () =>
   typeof window !== 'undefined' && window.__PLAYWRIGHT__ === true;
-
-function logWebAuthnResponse(label, credential) {
-  const response = credential?.response;
-  const getPublicKeyResult =
-    typeof response?.getPublicKey === 'function'
-      ? response.getPublicKey()
-      : null;
-
-  console.group(`[WebAuthn Debug] ${label}`);
-  console.log('credential', credential);
-  console.log('credential.id', credential?.id);
-  console.log('credential.type', credential?.type);
-  console.log('credential.rawId', credential?.rawId);
-  console.log('credential.response', response);
-  console.log('response.clientDataJSON', response?.clientDataJSON);
-  console.log('response.attestationObject', response?.attestationObject);
-  console.log('response.authenticatorData', response?.authenticatorData);
-  console.log('response.signature', response?.signature);
-  console.log('response.userHandle', response?.userHandle);
-  console.log(
-    'response.getPublicKey exists',
-    typeof response?.getPublicKey === 'function'
-  );
-  console.log('response.getPublicKey()', getPublicKeyResult);
-  console.log(
-    'client extension results',
-    credential?.getClientExtensionResults?.() || null
-  );
-  console.groupEnd();
-}
 
 /**
  * Extract public key info from a WebAuthn attestation object.

--- a/src/verification.js
+++ b/src/verification.js
@@ -7,6 +7,10 @@
  * without relying on external network calls or IPFS gateway timeouts.
  */
 
+import { logger } from '@libp2p/logger';
+
+const log = logger('orbitdb-identity-provider-webauthn-did:verification');
+
 /**
  * Verify database update events using pragmatic approach
  * @param {Object} database - The OrbitDB database instance
@@ -19,7 +23,7 @@ export async function verifyDatabaseUpdate(
   identityHash,
   expectedWebAuthnDID
 ) {
-  console.log('🔄 Verifying database update event');
+  log('🔄 Verifying database update event');
 
   // Simple logic: if an update is happening in our database and our database
   // identity matches the expected WebAuthn DID, then the update is from us
@@ -72,7 +76,7 @@ export async function verifyIdentityStorage(
   identity,
   timeoutMs = 5000
 ) {
-  console.log('🔍 Verifying identity storage...');
+  log('🔍 Verifying identity storage...');
 
   try {
     // Try to retrieve the identity from the store with a timeout
@@ -131,10 +135,8 @@ export async function verifyDataEntries(
   const { matchFn, checkLog = true } = options;
   const verificationResults = new Map();
 
-  console.log(
-    `🔍 Starting verification of ${dataEntries.length} data entries...`
-  );
-  console.log(`🎯 Expected WebAuthn DID: ${expectedWebAuthnDID}`);
+  log(`🔍 Starting verification of ${dataEntries.length} data entries...`);
+  log(`🎯 Expected WebAuthn DID: ${expectedWebAuthnDID}`);
 
   try {
     // Check if our database identity matches the expected WebAuthn DID
@@ -142,7 +144,7 @@ export async function verifyDataEntries(
     const databaseIdentityMatches =
       databaseIdentity?.id === expectedWebAuthnDID;
 
-    console.log('🔑 Database identity check:', {
+    log('🔑 Database identity check:', {
       databaseDID: databaseIdentity?.id,
       expectedDID: expectedWebAuthnDID,
       matches: databaseIdentityMatches,
@@ -150,7 +152,7 @@ export async function verifyDataEntries(
 
     for (const entry of dataEntries) {
       try {
-        console.log(`📝 Verifying entry: ${entry.id}`);
+        log(`📝 Verifying entry: ${entry.id}`);
 
         // Method 1: Check if we can access the entry in our database
         const entryInDb = await database.get(entry.id);
@@ -204,7 +206,7 @@ export async function verifyDataEntries(
 
         verificationResults.set(entry.id, result);
 
-        console.log(
+        log(
           `${verificationSuccess ? '✅' : '❌'} Entry ${entry.id}: ${verificationSuccess ? 'VERIFIED' : 'FAILED'}`
         );
       } catch (error) {
@@ -232,7 +234,7 @@ export async function verifyDataEntries(
     }
   }
 
-  console.log(
+  log(
     `✅ Verification completed: ${verificationResults.size} entries processed`
   );
   return verificationResults;

--- a/src/webauthn/debug-log.js
+++ b/src/webauthn/debug-log.js
@@ -1,0 +1,101 @@
+/**
+ * @module WebAuthnDebugLog
+ * @description
+ * Describes a WebAuthn credential or assertion for debugging without putting
+ * its contents anywhere.
+ *
+ * This replaces three copies of a helper that wrote the whole credential to
+ * `console` on every `navigator.credentials.create()` and `.get()` —
+ * unconditionally, in production code paths. Two reasons that mattered:
+ *
+ * - `getClientExtensionResults()` was logged verbatim. Since 0.4.1 the PRF
+ *   extension is requested on every credential, so that object can carry the
+ *   PRF output, which is the material both the keystore encryption and the
+ *   OrbitDB signing key are derived from.
+ * - `rawId` is a stable per-user, per-RP identifier. Emitting it on every call
+ *   put it into any console capture, error reporter or session replay the
+ *   embedding app happens to run.
+ *
+ * What is logged here is shape, not content: byte lengths, presence flags, and
+ * which extensions came back. Enough to tell "the authenticator returned no PRF
+ * result" from "the assertion never happened", which is what these logs were
+ * ever used for.
+ *
+ * See issue #22.
+ */
+import { logger } from '@libp2p/logger';
+
+const log = logger('orbitdb-identity-provider-webauthn-did:webauthn');
+
+/**
+ * Byte length of an ArrayBuffer or view, or null when absent.
+ * @param {ArrayBuffer|ArrayBufferView|null|undefined} value - Buffer-ish value.
+ * @returns {number|null} Length in bytes, or null.
+ */
+function byteLength(value) {
+  if (!value) return null;
+  if (typeof value.byteLength === 'number') return value.byteLength;
+  if (typeof value.length === 'number') return value.length;
+  return null;
+}
+
+/**
+ * Names of the extensions that returned results, without their values.
+ *
+ * The names alone are diagnostic — they say whether PRF engaged. The values are
+ * key material and never belong in a log.
+ *
+ * @param {PublicKeyCredential} credential - Credential or assertion.
+ * @returns {string[]|null} Extension names, or null if unavailable.
+ */
+function extensionNames(credential) {
+  try {
+    const results = credential?.getClientExtensionResults?.();
+    return results ? Object.keys(results) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Describe a WebAuthn response by shape alone.
+ *
+ * Every value here is a length, a boolean or an extension name. Nothing
+ * derived from credential bytes, and no extension values. Exported so the
+ * redaction can be asserted in tests rather than assumed.
+ *
+ * @param {PublicKeyCredential} credential - Credential or assertion.
+ * @returns {Object} Redacted description.
+ */
+export function describeWebAuthnResponse(credential) {
+  const response = credential?.response;
+
+  return {
+    type: credential?.type ?? null,
+    rawIdBytes: byteLength(credential?.rawId),
+    clientDataJSONBytes: byteLength(response?.clientDataJSON),
+    // Registration only.
+    attestationObjectBytes: byteLength(response?.attestationObject),
+    hasGetPublicKey: typeof response?.getPublicKey === 'function',
+    // Assertion only.
+    authenticatorDataBytes: byteLength(response?.authenticatorData),
+    signatureBytes: byteLength(response?.signature),
+    hasUserHandle: Boolean(response?.userHandle),
+    extensions: extensionNames(credential),
+  };
+}
+
+/**
+ * Log the shape of a WebAuthn response.
+ *
+ * Goes through the package debug logger, so it is off unless
+ * `DEBUG=orbitdb-identity-provider-webauthn-did*` is set, and it never writes
+ * credential contents.
+ *
+ * @param {string} label - What produced the response.
+ * @param {PublicKeyCredential} credential - Credential or assertion.
+ */
+export function logWebAuthnResponse(label, credential) {
+  if (!log.enabled) return;
+  log('%s returned: %o', label, describeWebAuthnResponse(credential));
+}

--- a/src/webauthn/provider.js
+++ b/src/webauthn/provider.js
@@ -27,38 +27,9 @@ import {
   buildAuthenticatorSelection,
   buildCredentialRequestOptions,
 } from './config.js';
+import { logWebAuthnResponse } from './debug-log.js';
 
 const webauthnLog = logger('orbitdb-identity-provider-webauthn-did:webauthn');
-
-function logWebAuthnResponse(label, credential) {
-  const response = credential?.response;
-  const getPublicKeyResult =
-    typeof response?.getPublicKey === 'function'
-      ? response.getPublicKey()
-      : null;
-
-  console.group(`[WebAuthn Debug] ${label}`);
-  console.log('credential', credential);
-  console.log('credential.id', credential?.id);
-  console.log('credential.type', credential?.type);
-  console.log('credential.rawId', credential?.rawId);
-  console.log('credential.response', response);
-  console.log('response.clientDataJSON', response?.clientDataJSON);
-  console.log('response.attestationObject', response?.attestationObject);
-  console.log('response.authenticatorData', response?.authenticatorData);
-  console.log('response.signature', response?.signature);
-  console.log('response.userHandle', response?.userHandle);
-  console.log(
-    'response.getPublicKey exists',
-    typeof response?.getPublicKey === 'function'
-  );
-  console.log('response.getPublicKey()', getPublicKeyResult);
-  console.log(
-    'client extension results',
-    credential?.getClientExtensionResults?.() || null
-  );
-  console.groupEnd();
-}
 
 /**
  * WebAuthn DID Provider Core Implementation

--- a/tests/webauthn-debug-log.test.js
+++ b/tests/webauthn-debug-log.test.js
@@ -1,0 +1,132 @@
+/**
+ * Guards the redaction in the WebAuthn debug logger.
+ *
+ * The helper this replaced wrote the whole credential to console on every
+ * call — including getClientExtensionResults(), which since 0.4.1 can carry
+ * the PRF output, the material both keystore encryption and the OrbitDB
+ * signing key derive from. See issue #22.
+ */
+import { test, expect } from '@playwright/test';
+
+import {
+  describeWebAuthnResponse,
+  logWebAuthnResponse,
+} from '../src/webauthn/debug-log.js';
+
+const PRF_SECRET = new Uint8Array(32).fill(0xab);
+const SIGNATURE = new Uint8Array(64).fill(0xcd);
+const RAW_ID = new Uint8Array(32).fill(0xef);
+
+function assertionWithPrf() {
+  return {
+    id: 'credential-id',
+    rawId: RAW_ID.buffer,
+    type: 'public-key',
+    response: {
+      authenticatorData: new Uint8Array(37).buffer,
+      clientDataJSON: new TextEncoder().encode('{"type":"webauthn.get"}')
+        .buffer,
+      signature: SIGNATURE.buffer,
+      userHandle: null,
+    },
+    getClientExtensionResults: () => ({
+      prf: { results: { first: PRF_SECRET.buffer } },
+    }),
+  };
+}
+
+test.describe('WebAuthn debug logging', () => {
+  test('describes an assertion by shape only', () => {
+    const described = describeWebAuthnResponse(assertionWithPrf());
+
+    expect(described).toEqual({
+      type: 'public-key',
+      rawIdBytes: 32,
+      clientDataJSONBytes: 23,
+      attestationObjectBytes: null,
+      hasGetPublicKey: false,
+      authenticatorDataBytes: 37,
+      signatureBytes: 64,
+      hasUserHandle: false,
+      extensions: ['prf'],
+    });
+  });
+
+  test('reports that PRF engaged without revealing its output', () => {
+    const described = describeWebAuthnResponse(assertionWithPrf());
+    const serialised = JSON.stringify(described);
+
+    // The name is the diagnostic; the value is key material.
+    expect(described.extensions).toContain('prf');
+    expect(serialised).not.toContain('results');
+    expect(serialised).not.toContain('ab');
+  });
+
+  test('carries no credential bytes at all', () => {
+    const serialised = JSON.stringify(
+      describeWebAuthnResponse(assertionWithPrf())
+    );
+
+    for (const [name, bytes] of [
+      ['PRF output', PRF_SECRET],
+      ['signature', SIGNATURE],
+      ['rawId', RAW_ID],
+    ]) {
+      const hex = Buffer.from(bytes).toString('hex');
+      const base64 = Buffer.from(bytes).toString('base64');
+      expect(serialised, `${name} must not appear as hex`).not.toContain(hex);
+      expect(serialised, `${name} must not appear as base64`).not.toContain(
+        base64
+      );
+    }
+  });
+
+  test('handles a registration response', () => {
+    const described = describeWebAuthnResponse({
+      type: 'public-key',
+      rawId: RAW_ID.buffer,
+      response: {
+        attestationObject: new Uint8Array(194).buffer,
+        clientDataJSON: new Uint8Array(133).buffer,
+        getPublicKey: () => new Uint8Array(91).buffer,
+      },
+      getClientExtensionResults: () => ({}),
+    });
+
+    expect(described.attestationObjectBytes).toBe(194);
+    expect(described.hasGetPublicKey).toBe(true);
+    expect(described.authenticatorDataBytes).toBeNull();
+    expect(described.extensions).toEqual([]);
+  });
+
+  test('survives a malformed or empty response', () => {
+    expect(() => describeWebAuthnResponse(undefined)).not.toThrow();
+    expect(() => describeWebAuthnResponse({})).not.toThrow();
+
+    const described = describeWebAuthnResponse({
+      getClientExtensionResults: () => {
+        throw new Error('not available');
+      },
+    });
+    expect(described.extensions).toBeNull();
+  });
+
+  test('writes nothing to console when the debug logger is off', () => {
+    const seen = [];
+    const originals = {};
+    for (const level of ['log', 'group', 'groupEnd', 'info', 'debug']) {
+      originals[level] = console[level];
+      console[level] = (...args) => seen.push([level, args]);
+    }
+
+    try {
+      logWebAuthnResponse('navigator.credentials.get()', assertionWithPrf());
+    } finally {
+      for (const [level, fn] of Object.entries(originals)) {
+        console[level] = fn;
+      }
+    }
+
+    expect(seen).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #22.

## What was happening

`logWebAuthnResponse()` wrote the whole credential to `console` on every `navigator.credentials.create()` and `.get()` — unconditionally, not behind the debug logger, in production code paths:

```js
console.log('credential', credential);
console.log('credential.rawId', credential?.rawId);
console.log('response.signature', response?.signature);
console.log('response.getPublicKey()', getPublicKeyResult);
console.log('client extension results', credential?.getClientExtensionResults?.() || null);
```

It even *called* `getPublicKey()` purely to log the result.

Two things made that more than noise:

- **Extension results can carry the PRF output** — the material both the keystore encryption and, since 0.4.1, the OrbitDB signing key derive from. 0.4.1 made this sharper than when the issue was filed: PRF is now requested on **every** credential, not only encrypted ones, so the path that could log it is wider.
- **`rawId` is a stable per-user, per-RP identifier**, emitted on every call into whatever console capture, error reporter or session replay the embedding app happens to run.

## What it does now

One shared helper in `src/webauthn/debug-log.js`, replacing three byte-identical copies. It logs shape only:

```
{ type, rawIdBytes, clientDataJSONBytes, attestationObjectBytes,
  hasGetPublicKey, authenticatorDataBytes, signatureBytes,
  hasUserHandle, extensions: ['prf'] }
```

Extension **names** are kept — they are the actual diagnostic, since they tell you whether PRF engaged — while the values never appear. Everything goes through the package debug logger, so it is silent unless `DEBUG=orbitdb-identity-provider-webauthn-did*` is set, and it returns early when the logger is off.

The description is exposed as `describeWebAuthnResponse()` so the redaction can be **asserted rather than assumed**. The tests check that the PRF output, the signature and `rawId` appear in the result in neither hex nor base64, and that nothing reaches `console` while the logger is disabled.

## The sweep

Also routes the remaining informational `console.log` through the debug logger, which the issue suggested doing in the same pass. A library should not print unconditionally.

`console.error` and `console.warn` are deliberately left alone — a library swallowing genuine failures silently is worse than one that reports them.

```
src/ console.*   61 → 16   (0 console.log, 7 console.error, 9 console.warn)
```

## Verification

```
new debug-log cases      6 passed
node suites             40 passed
varsig e2e               1 passed
browser suites          28 passed
encrypted-keystore      27 passed
```

The varsig e2e run matters here — two of the three deduplicated copies lived in `src/varsig/`, so that suite is the one that would notice a bad merge of the helper.

Unreleased for now; no version bump, so this ships with whatever comes next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
